### PR TITLE
Add github.io docs pages for project status/version/guidelines/templates/topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Please make sure to update it on a regular basis – when new files or folder ar
 
 Check out our [onboarding guidance for new participants](https://github.com/cosai-oasis/oasis-open-project/blob/main/ONBOARDING.md) and please see the [CoSAI Contributing policy](./CONTRIBUTING.md) for more details.
 
+### Project Documentation Site (Draft)
+
+Initial `github.io` content for this repository is available in [`github-io/index.md`](./github-io/index.md), including:
+
+- project documentation
+- current status
+- current version
+- contribution guidelines
+- templates
+- working topics
+
 <!-- Give a brief explanation of what kind of contributions you are looking for and what your requirements are for accepting them. Then link to
 [CONTRIBUTING.md](link to your contributing.md file) for more information and also add a link to [CODE_OF_CONDUCT](link to your code_of_conduct.md file).
 
@@ -70,5 +81,4 @@ CoSAI and the CoSAI workstream operates under the terms of the [Open Project Rul
   
 The applicable license will be determined for each repository, as applicable, at the time of its
 creation.
-
 

--- a/github-io/contribution-guidelines.md
+++ b/github-io/contribution-guidelines.md
@@ -1,0 +1,22 @@
+# Contribution Guidelines
+
+## Required Flow
+
+1. Open or reference an issue before editing.
+2. Confirm editorial vs conceptual scope.
+3. Confirm target milestone.
+4. Confirm project board status.
+5. Submit a pull request with linked issue.
+
+## Review Expectations
+
+- Keep PR scope aligned to one issue.
+- Include rationale and trade-offs.
+- Capture decisions in PR or issue comments.
+- Address review feedback before merge.
+
+## Ownership
+
+- Contributors: implement scoped changes.
+- Integration or topic maintainers: ensure coherence.
+- Leads: approve final merges for published state.

--- a/github-io/current-status.md
+++ b/github-io/current-status.md
@@ -1,0 +1,25 @@
+# Current Status
+
+## Date
+
+2026-03-17
+
+## Status
+
+Active.
+
+## Current Phase
+
+Repository process hardening and documentation alignment.
+
+## Highlights
+
+- Workflow and contributor guideline package drafted.
+- Issue and PR templates prepared for consistent intake and review.
+- GitHub Pages documentation proposal converted into implementation content.
+
+## Near-Term Next Steps
+
+1. Finalize branch protection and review policy.
+2. Align issues to milestones and project board states.
+3. Publish approved `github.io` pages from `main`.

--- a/github-io/current-version.md
+++ b/github-io/current-version.md
@@ -1,0 +1,15 @@
+# Current Version
+
+## Project Documentation Version
+
+`v0.1.0-draft` (2026-03-17)
+
+## Release Intent
+
+- `v1.0` initial publication baseline
+- `v1.1` editorial cleanup
+- `v1.2` conceptual expansion and cookbook additions
+
+## Version Rule
+
+Working iterations happen in GitHub branches and pull requests. Formal versions are tagged from approved `main` content.

--- a/github-io/index.md
+++ b/github-io/index.md
@@ -1,0 +1,16 @@
+# WS4 GitHub Pages Documentation
+
+This directory contains the initial content set for publishing project information through `github.io`.
+
+## Navigation
+
+- [Project Documentation](./project-documentation.md)
+- [Current Status](./current-status.md)
+- [Current Version](./current-version.md)
+- [Contribution Guidelines](./contribution-guidelines.md)
+- [Templates](./templates.md)
+- [Working Topics](./working-topics.md)
+
+## Source Of Truth
+
+GitHub issues, pull requests, milestones, and project boards remain the source of truth for the working process and release decisions.

--- a/github-io/project-documentation.md
+++ b/github-io/project-documentation.md
@@ -1,0 +1,27 @@
+# Project Documentation
+
+## Purpose
+
+Workstream 4 maintains security guidance for agentic systems, including whitepapers, RFC content, and practical guides.
+
+## Scope
+
+- Design patterns for secure-by-design agentic systems
+- Threat modeling and trust boundary guidance
+- Deployment and operational recommendations
+- Supporting RFC and practical guide artifacts
+
+## Canonical Repository Artifacts
+
+- `model-context-protocol-security.md`
+- `rfc-mcp_handshake.md`
+- `practical-guides/mcp-secure-tool-design.md`
+- `whitepaper-template.md`
+
+## Collaboration Model
+
+1. Start with an issue for each change.
+2. Classify as editorial or conceptual.
+3. Assign milestone and project status.
+4. Implement through branch and pull request workflow.
+5. Preserve rationale in GitHub comments.

--- a/github-io/templates.md
+++ b/github-io/templates.md
@@ -1,0 +1,21 @@
+# Templates
+
+## Repository Templates
+
+- `whitepaper-template.md`
+- `rfc-template.md`
+
+## Suggested Process Templates
+
+- Issue template for change intake and classification
+- Pull request template for review consistency
+
+## Minimum Template Metadata
+
+- Affected document or topic
+- Change type (`editorial` or `conceptual`)
+- Problem statement
+- Proposed change
+- Milestone target
+- Project board status
+- Linked dependencies

--- a/github-io/working-topics.md
+++ b/github-io/working-topics.md
@@ -1,0 +1,21 @@
+# Working Topics
+
+## Primary Topics
+
+- MCP security whitepaper evolution
+- MCP handshake RFC refinement
+- Secure tool design practical guidance
+- Identity, isolation, and red-teaming companion material
+
+## Topic Tracking
+
+Each topic should map to:
+
+- linked issues
+- milestone target
+- project board status
+- active pull request (if in progress)
+
+## Cross-Time-Zone Operating Rule
+
+Important decisions made in Slack should be summarized back into GitHub issue or pull request comments.


### PR DESCRIPTION
## Summary
Adds an initial github.io documentation section for WS4 with dedicated pages for project documentation, current status, current version, contribution guidelines, templates, and working topics.

## Changes
- Added github-io/index.md as the docs landing page
- Added github-io/project-documentation.md
- Added github-io/current-status.md
- Added github-io/current-version.md
- Added github-io/contribution-guidelines.md
- Added github-io/templates.md
- Added github-io/working-topics.md
- Updated README.md with a link to the new github.io docs section

## Intent
Establishes a first publishable docs structure for a future GitHub Pages site while keeping GitHub issues, PRs, milestones, and projects as the operational source of truth.
