### PR TITLE
Restoring and relocating CoSAI practical guide patterns

### DIFF
--- a/practical-guides/artifact-integrity-maturity/artifact-integrity-maturity-pattern.md
+++ b/practical-guides/artifact-integrity-maturity/artifact-integrity-maturity-pattern.md
@@ -1,0 +1,489 @@
+---
+title: Artifact Integrity Maturity Model
+nav_order: 2
+parent: Standards
+has_toc: true
+---
+
+# Artifact Integrity Maturity Model
+## Progressive Security for AI Artifact Provenance
+
+**Version:** 1.0.0  
+**Status:** Draft  
+**Authors:** David Pierce, MPA @ PayPal ; Daniel Rohher @ Nvidia
+**Last Updated:** 2025-01-22  
+**Framework Alignment:** CoSAI-RM, MITRE ATLAS, OWASP LLM Top 10, SLSA, in-toto
+
+---
+
+## Abstract
+
+AI artifacts (models, training data, configurations) require cryptographic proof of integrity, lineage, and policy compliance. This standard defines a **progressive maturity model** enabling organizations to start with basic integrity and advance to full attestation-based provenance as operational requirements grow.
+
+The model addresses three orthogonal concerns: **claims** (what can be proven), **topology** (how artifacts relate), and **verification** (how proofs are validated).
+
+---
+
+## The Fundamental Problem
+
+```mermaid
+flowchart LR
+    subgraph traditional["Traditional"]
+        T1["Model v1.0"] --> T2["Model v1.1"] --> T3["???"]
+    end
+    
+    subgraph maturity["With Maturity Model"]
+        M1["v1.0 + hash + signature"] --> M2["v1.1 + lineage + inputs verified"] --> M3["v1.2 + attestations + policy pass"]
+    end
+    
+    traditional -.->|"What changed? Who approved? Is it safe?"| maturity
+    
+    style traditional fill:#ffebee,stroke:#c62828
+    style maturity fill:#e8f5e9,stroke:#2e7d32
+```
+
+**The vulnerability:** Artifacts flow through ML pipelines without cryptographic proof of what they are, where they came from, or whether they're safe to deploy.
+
+**The solution:** Progressive claims that prove integrity (L1), lineage (L2), and policy compliance (L3).
+
+---
+
+## Maturity Levels
+
+| Level | Name | Proves | Topology |
+|-------|------|--------|----------|
+| **1** | Basic Integrity | "This artifact exists, was created by X, and hasn't changed" | Chain |
+| **2** | Chaining & Lineage | "This artifact was derived from verified inputs through a documented process" | Chain, Tree |
+| **3** | Attestations & Policy | "This artifact meets policy requirements and is approved for deployment" | Chain, Tree, DAG |
+
+---
+
+## Invariants by Level
+
+### Level 1: Basic Integrity
+
+| ID | Invariant | Assertion | Required |
+|----|-----------|-----------|----------|
+| INV-L1-01 | **Measured** | `H(artifact_content) == integrity.digest` | ✓ |
+| INV-L1-02 | **Produced By** | `signature.signer == claimed_producer` | ✓ |
+| INV-L1-03 | **Signer Verified** | `signer.subject ∈ trust_store` | ✓ |
+| INV-L1-04 | **Timestamped** | `|now() - signed_at| < tolerance` | ○ |
+
+**Formal Claims:**
+```
+MEASURED <TARGET X> as (hash) SIGNED BY A
+<TARGET X> was PRODUCED BY A
+SIGNER A verified against trust_store
+```
+
+### Level 2: Chaining and Lineage
+
+| ID | Invariant | Assertion | Required |
+|----|-----------|-----------|----------|
+| INV-L2-01 | **Derived From** | `lineage.inputs[].artifact_id EXISTS` | ✓ |
+| INV-L2-02 | **Input Verified** | `∀ input: H(input) == original_digest` | ✓ |
+| INV-L2-03 | **Evidence Backed** | `derivation_claim.evidence EXISTS` | ○ |
+| INV-L2-04 | **Chain Linked** | `H(prev.sig) == chain_signature.prev_hash` | ✓ |
+| INV-L2-05 | **Timestamped (Strict)** | `|now() - signed_at| < 60s` | ✓ |
+
+**Formal Claims:**
+```
+<TARGET Y> was DERIVED FROM <TARGET X> SIGNED BY A
+INPUT <TARGET X> was VERIFIED as Hash
+INPUT <X.1> was DERIVED FROM <X> BY <PROCESS> SIGNED BY A
+```
+
+### Level 3: Attestations and Policy
+
+| ID | Invariant | Assertion | Required |
+|----|-----------|-----------|----------|
+| INV-L3-01 | **Attested (Process)** | `attestations.process EXISTS + signed` | ✓ |
+| INV-L3-02 | **Attested (Model)** | `IF type=model: attestations.model EXISTS` | Conditional |
+| INV-L3-03 | **Attested (Data)** | `IF uses_training_data: attestations.data EXISTS` | Conditional |
+| INV-L3-04 | **Attested (Infra)** | `attestations.infrastructure EXISTS` | ○ |
+| INV-L3-05 | **Policy Evaluated** | `policy.evaluations[].result ∈ {PASS, WARN}` | ✓ |
+| INV-L3-06 | **Admission Gated** | `IF deploying: admission_status.admitted` | Conditional |
+
+**Formal Claims:**
+```
+ATTESTED(process) by attester SIGNED
+ATTESTED(model) with metrics SIGNED
+POLICY_EVALUATED with result
+ADMISSION_GATED for target environment
+```
+
+---
+
+## Topology Selection
+
+Organizations select lineage topology based on operational requirements:
+
+```mermaid
+flowchart TB
+    subgraph chain["CHAIN (Level 1)"]
+        direction LR
+        C1["v1.0"] --> C2["v1.1"] --> C3["v1.2"]
+    end
+    
+    subgraph tree["TREE (Level 2)"]
+        direction TB
+        T1["base"]
+        T2["data"]
+        T3["config"]
+        T4["trained"]
+        T1 --> T4
+        T2 --> T4
+        T3 --> T4
+    end
+    
+    subgraph dag["DAG (Level 3)"]
+        direction TB
+        D1["base"]
+        D2["fork_a"]
+        D3["fork_b"]
+        D4["merged"]
+        D1 --> D2
+        D1 --> D3
+        D2 --> D4
+        D3 --> D4
+    end
+    
+    style chain fill:#e8f5e9,stroke:#2e7d32
+    style tree fill:#e3f2fd,stroke:#1976d2
+    style dag fill:#f3e5f5,stroke:#7b1fa2
+```
+
+| Topology | Max Inputs | Branching | Merging | Verification | Use Case |
+|----------|------------|-----------|---------|--------------|----------|
+| **Chain** | 1 | ✗ | ✗ | O(n) | Version history |
+| **Tree** | ∞ | ✓ | ✗ | O(n) DFS | Training pipelines |
+| **DAG** | ∞ | ✓ | ✓ | O(V+E) | Model merging, ensembles |
+
+---
+
+## Sensible Defaults
+
+### Level 1 Defaults
+
+```yaml
+integrity:
+  algorithm: SHA256
+  alternatives: [SHA384, SHA512, SHA3-256]
+
+signature:
+  algorithm: RS256
+  alternatives: [ES256, ES384, EdDSA]
+  key_rotation_days: 90
+  min_key_size_rsa: 2048
+  min_key_size_ec: 256
+
+timestamp:
+  required: false
+  tolerance_seconds: 300
+  source: local
+
+trust_store:
+  type: static
+  refresh_hours: 24
+```
+
+### Level 2 Defaults (Overrides)
+
+```yaml
+timestamp:
+  required: true           # Now mandatory
+  tolerance_seconds: 60    # Stricter
+  source: tsa              # Time Stamping Authority
+
+lineage:
+  max_chain_depth: 100
+  input_verification: required
+  process_parameters_hash: required
+  log_retention_days: 365
+```
+
+### Level 3 Defaults (Overrides)
+
+```yaml
+signature:
+  algorithm: ES384         # Stronger curve
+
+attestations:
+  required_categories: [process]
+  recommended_categories: [model, data, process, infrastructure]
+  predicate_types:
+    default: "https://in-toto.io/attestation/v1"
+    provenance: "https://slsa.dev/provenance/v1"
+  attester_trust_level_for_production: high
+
+policy:
+  engine: opa
+  format: rego
+  minimum_rules:
+    - artifact_integrity
+    - lineage_verified
+    - attestations_present
+  admission_controller: gatekeeper
+
+compliance:
+  evidence_retention_days: 2555  # 7 years
+  check_frequency: daily
+```
+
+---
+
+## Risks & Controls
+
+### Risk: Artifact Tampering (ATLAS: AML.T0048)
+**Threat:** Artifact content modified after signing.  
+**Control:** INV-L1-01 — Hash verification detects any modification.
+
+### Risk: Lineage Manipulation
+**Threat:** False derivation claims or input substitution.  
+**Control:** INV-L2-02 — All input hashes verified before derivation.
+
+### Risk: Diamond Inconsistency (DAG only)
+**Threat:** Same artifact has different hashes via different paths.  
+**Control:** Diamond consistency check during DAG verification.
+
+### Risk: Attestation Forgery (ATLAS: AML.T0043)
+**Threat:** False attestations about model performance or data provenance.  
+**Control:** INV-L3-01/02/03 — Attestation signatures verified against trusted attesters.
+
+### Risk: Policy Bypass
+**Threat:** Deployment without required policy evaluation.  
+**Control:** INV-L3-05/06 — Policy evaluation and admission gate required.
+
+---
+
+## Validation Sequence
+
+### Level 1
+
+```
+1. VERIFY signature.algorithm ∈ allowed_algorithms
+2. VERIFY signature over canonical manifest              [INV-L1-02]
+3. VERIFY signer.subject ∈ trust_store                   [INV-L1-03]
+4. VERIFY H(artifact_content) == integrity.digest        [INV-L1-01] ← critical
+5. IF timestamp: VERIFY |now() - signed_at| < tolerance  [INV-L1-04]
+6. RETURN {measured: ✓, produced_by: ✓, signer_verified: ✓}
+```
+
+### Level 2 (extends Level 1)
+
+```
+7.  VERIFY chain_position > 0 OR chain_integrity == "GENESIS"
+8.  FOR EACH input: VERIFY H(input) == original_digest   [INV-L2-02] ← critical
+9.  IF previous: VERIFY H(prev.sig) == prev_sig_hash     [INV-L2-04]
+10. IF topology == TREE: VERIFY no_diamonds(graph)
+11. IF EVIDENCE_BACKED: VERIFY evidence exists           [INV-L2-03]
+12. RETURN L1 + {derived_from: ✓, inputs_verified: ✓, chain_valid: ✓}
+```
+
+### Level 3 (extends Level 2)
+
+```
+13. IF topology == DAG: VERIFY no_cycles(graph)
+14. IF topology == DAG: VERIFY diamond_consistency(graph)
+15. VERIFY attestations.process EXISTS + signature       [INV-L3-01]
+16. IF type=model: VERIFY attestations.model EXISTS      [INV-L3-02]
+17. IF uses_training_data: VERIFY attestations.data      [INV-L3-03]
+18. FOR EACH eval: VERIFY result ∈ {PASS, WARN}          [INV-L3-05]
+19. IF deploying: VERIFY admitted == true                [INV-L3-06]
+20. RETURN L2 + {attested: ✓, policy_passed: ✓, admitted: ✓}
+```
+
+---
+
+## Multi-Party Claim Navigation
+
+When claims come from different parties:
+
+```mermaid
+flowchart TB
+    subgraph parties["Different Signing Parties"]
+        ALICE["Alice (Producer)\nPRODUCED_BY(X)"]
+        BOB["Bob (Consumer)\nINPUT_VERIFIED(X)"]
+        CAROL["Carol (Pipeline)\nDERIVED_FROM(Y←X)"]
+        DAVE["Dave (ML Validator)\nATTESTED(model, Y)"]
+        EVE["Eve (Security)\nATTESTED(infra, Y)"]
+    end
+    
+    subgraph index["Pointer-by-Subject Index"]
+        X["claims['X'] = {\n  PRODUCED_BY (Alice),\n  INPUT_VERIFIED (Bob)\n}"]
+        Y["claims['Y'] = {\n  DERIVED_FROM (Carol),\n  ATTESTED:model (Dave),\n  ATTESTED:infra (Eve)\n}"]
+    end
+    
+    ALICE --> X
+    BOB --> X
+    CAROL --> Y
+    DAVE --> Y
+    EVE --> Y
+```
+
+### Verification Algorithm
+
+```python
+def verify_multi_party(artifact_id, trust_policy):
+    # 1. Collect all claims about this artifact
+    claims = collect_claims_by_subject(artifact_id)
+    
+    # 2. Verify each claim's signature independently
+    for claim in claims:
+        verify_signature(claim, claim.signer)
+        verify_signer_trusted(claim.signer, trust_policy)
+    
+    # 3. Recurse into referenced artifacts (DAG traversal)
+    for input_ref in get_input_references(claims):
+        verify_multi_party(input_ref.artifact_id, trust_policy)
+    
+    # 4. Check claim completeness per level
+    assert has_required_claims(claims, artifact.maturity_level)
+    
+    # 5. Evaluate cross-claim consistency
+    assert claims_consistent(claims)
+```
+
+### Conflict Resolution Strategies
+
+| Strategy | Description | Use When |
+|----------|-------------|----------|
+| **FAIL** | Any conflict fails verification | High-security environments |
+| **QUORUM** | Majority of trusted parties wins | Distributed trust |
+| **PRIORITY** | Higher trust level wins | Hierarchical trust |
+| **TEMPORAL** | Most recent claim wins | Evolving state |
+
+---
+
+## Framework Mappings
+
+| Standard | Reference | Coverage |
+|----------|-----------|----------|
+| **MITRE ATLAS** | AML.T0043, AML.T0048 | Supply chain, data manipulation |
+| **OWASP LLM Top 10** | LLM03, LLM06, LLM08 | Training data poisoning, excessive agency |
+| **SLSA** | Levels 1-4 | Build provenance |
+| **in-toto** | Attestation framework | Attestation predicates |
+| **STRIDE** | All categories | Full coverage |
+| **NIST AI RMF** | GOVERN, MAP, MEASURE, MANAGE | Risk governance |
+
+---
+
+## Compliance Mappings
+
+| Framework | Controls | Evidence Sources |
+|-----------|----------|------------------|
+| **SOC2** | CC6.1, CC7.1, CC7.2 | attestations.process, attestations.infrastructure |
+| **NIST AI RMF** | GOVERN-1.1, MAP-3.1, MEASURE-2.1 | attestations.model, attestations.data |
+| **ISO 27001** | A.12.1, A.14.2 | attestations.infrastructure, policy.evaluations |
+| **PCI DSS** | 6.3, 6.5, 10.1 | audit, lineage, attestations.process |
+
+---
+
+## Implementation Checklist
+
+### Level 1: Basic Integrity
+
+```yaml
+checklist:
+  - [ ] Generate unique artifact IDs
+  - [ ] Compute SHA256 hash of content
+  - [ ] Sign artifact manifest with RS256/ES256
+  - [ ] Store signer certificate in trust store
+  - [ ] Implement hash verification on access
+  - [ ] Include L2 anchor points in schema
+```
+
+### Level 2: Chaining and Lineage
+
+```yaml
+checklist:
+  - [ ] Add chain tracking (chain_id, chain_position)
+  - [ ] Verify all input artifact hashes before derivation
+  - [ ] Include chain_signature linking to previous
+  - [ ] Add derivation_claim with evidence
+  - [ ] Implement DPoP for Class 1-3 data
+  - [ ] Require ticket ID for Class 1-3 operations
+  - [ ] Include L3 anchor points in schema
+```
+
+### Level 3: Attestations and Policy
+
+```yaml
+checklist:
+  - [ ] Add attestations.process (always required)
+  - [ ] Add attestations.model (when type=model)
+  - [ ] Add attestations.data (when using training data)
+  - [ ] Configure OPA/Rego policy evaluation
+  - [ ] Implement Gatekeeper admission control
+  - [ ] Map to compliance frameworks
+  - [ ] Enable automated compliance checks
+  - [ ] IF DAG: Implement cycle detection + diamond consistency
+```
+
+---
+
+## Security Guarantees
+
+When all invariants for a level are satisfied:
+
+| Level | Guarantees |
+|-------|------------|
+| **L1** | Integrity (content matches hash), Authenticity (signer verified), Non-tampering (modifications detected) |
+| **L2** | + Lineage (inputs verified), Reproducibility (process documented), Chain integrity (no breaks) |
+| **L3** | + Attestation validity (signed by trusted parties), Policy compliance (rules passed), Deployment safety (admitted) |
+
+---
+
+## Appendix A: Claim Progression Summary
+
+```
+LEVEL 1 (Basic Integrity)
+├── MEASURED: H(content) SIGNED BY A
+├── PRODUCED_BY: <X> was PRODUCED BY A  
+├── SIGNER_VERIFIED: A ∈ trust_store
+└── TIMESTAMPED: t ∈ range (OPTIONAL)
+
+LEVEL 2 (Chaining + Lineage) — Inherits Level 1
+├── DERIVED_FROM: <Y> DERIVED FROM <X> SIGNED BY A
+├── INPUT_VERIFIED: INPUT <X> VERIFIED as Hash
+├── EVIDENCE_BACKED: <X.1> DERIVED FROM <X> BY <PROCESS> SIGNED BY A
+└── CHAIN_LINKED: H(prev_sig) in chain_signature
+
+LEVEL 3 (Attestations + Policy) — Inherits Level 2
+├── ATTESTED (process): SLSA provenance SIGNED BY attester
+├── ATTESTED (model): Metrics + fairness SIGNED BY attester (conditional)
+├── ATTESTED (data): Source + PII scan SIGNED BY attester (conditional)
+├── ATTESTED (infra): Security controls SIGNED BY attester (recommended)
+├── POLICY_EVALUATED: OPA result with rule details
+└── ADMISSION_GATED: Explicit admission decision (conditional)
+```
+
+---
+
+## Appendix B: Relationship to Zero-Trust Tool Invocation
+
+This maturity model complements the Zero-Trust Tool Invocation standard:
+
+| Concern | Zero-Trust Tool Invocation | Artifact Integrity Maturity |
+|---------|---------------------------|----------------------------|
+| **Focus** | Runtime authorization | Artifact provenance |
+| **Time** | Point-in-time execution | Lifecycle tracking |
+| **Binding** | Identity → Tool → Parameters | Producer → Artifact → Lineage |
+| **Key Invariant** | Parameter hash at execution | Content hash at creation |
+| **Integration** | Level 2+ operations may require artifact verification before tool authorization |
+
+When deploying Class 1-3 operations that involve AI artifacts:
+1. Verify artifact integrity per this maturity model
+2. Authorize tool invocation per Zero-Trust standard
+3. Execute with both proofs in audit trail
+
+---
+
+## References
+
+- [CoSAI Risk Map](https://github.com/cosai-oasis/cosai-rm)
+- [MITRE ATLAS](https://atlas.mitre.org/)
+- [SLSA Framework](https://slsa.dev/)
+- [in-toto Attestations](https://in-toto.io/)
+- [OWASP Top 10 for LLM](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework)

--- a/practical-guides/artifact-integrity-maturity/artifact-integrity-maturity.cosai-rm.yaml
+++ b/practical-guides/artifact-integrity-maturity/artifact-integrity-maturity.cosai-rm.yaml
@@ -1,0 +1,773 @@
+# Artifact Integrity Maturity Model - CoSAI-RM Schema
+# Version: 1.0.0
+
+metadata:
+  name: artifact-integrity-maturity-model
+  version: "1.0.0"
+  status: draft
+  description: >
+    Progressive security model for AI artifact provenance enabling cryptographic
+    proof of integrity, lineage, and policy compliance across artifact lifecycles.
+  framework_mappings:
+    - cosai-rm
+    - mitre-atlas
+    - owasp-llm-top10
+    - nist-ai-rmf
+    - stride
+    - slsa
+    - in-toto
+
+# ============================================================================
+# INVARIANTS (Floor Claims by Maturity Level)
+# ============================================================================
+
+invariants:
+  # --- Level 1: Basic Integrity ---
+  - id: INV-L1-01
+    name: Measured
+    level: 1
+    assertion: "H(artifact_content) == integrity.digest"
+    formal: "MEASURED <TARGET X> as (hash) SIGNED BY A"
+    description: Cryptographic commitment to artifact content
+    required: true
+    
+  - id: INV-L1-02
+    name: Produced By
+    level: 1
+    assertion: "signature.signer == claimed_producer"
+    formal: "<TARGET X> was PRODUCED BY A"
+    description: Ownership/responsibility claim linking artifact to producer
+    required: true
+    
+  - id: INV-L1-03
+    name: Signer Verified
+    level: 1
+    assertion: "signer.subject ∈ trust_store"
+    formal: "SIGNER A verified against trust_store"
+    description: Signer identity validated against recognized trust store
+    required: true
+    
+  - id: INV-L1-04
+    name: Timestamped
+    level: 1
+    assertion: "|now() - signed_at| < tolerance"
+    formal: "TIMESTAMP t within acceptable range"
+    description: Signature timestamp within acceptable drift
+    required: false  # Optional at L1, Required at L2+
+    default_tolerance_seconds: 300
+    
+  # --- Level 2: Chaining and Lineage ---
+  - id: INV-L2-01
+    name: Derived From (Null Provenance)
+    level: 2
+    assertion: "lineage.inputs[].artifact_id EXISTS"
+    formal: "<TARGET Y> was DERIVED FROM <TARGET X> SIGNED BY A"
+    description: Basic derivation claim without process details
+    required: true
+    
+  - id: INV-L2-02
+    name: Input Verified
+    level: 2
+    assertion: "∀ input ∈ lineage.inputs: H(input.content) == input.verification.original_digest"
+    formal: "INPUT <TARGET X> was VERIFIED as Hash"
+    description: All input artifact hashes validated before derivation
+    required: true
+    critical: true
+    
+  - id: INV-L2-03
+    name: Evidence Backed
+    level: 2
+    assertion: "derivation_claim.evidence.process_log_hash EXISTS"
+    formal: "INPUT <X.1> was DERIVED FROM <X> BY <PROCESS> SIGNED BY A"
+    description: Full derivation with process reference and evidence
+    required: false  # Required for EVIDENCE_BACKED claim type
+    
+  - id: INV-L2-04
+    name: Chain Linked
+    level: 2
+    assertion: "H(previous.signature) == chain_signature.previous_signature_hash"
+    formal: "CHAIN_SIGNATURE links to predecessor"
+    description: Cryptographic linkage to predecessor artifact
+    required: true
+    
+  - id: INV-L2-05
+    name: Timestamped (Strict)
+    level: 2
+    assertion: "|now() - signed_at| < strict_tolerance"
+    formal: "TIMESTAMP t within strict range"
+    description: Signature timestamp with stricter tolerance
+    required: true  # Now required at L2+
+    default_tolerance_seconds: 60
+    source: tsa_preferred
+    
+  # --- Level 3: Attestations and Policy ---
+  - id: INV-L3-01
+    name: Attested (Process)
+    level: 3
+    assertion: "attestations.process EXISTS AND verify(attestations.process.signature)"
+    formal: "ATTESTED(process) by attester SIGNED"
+    description: Process attestation with valid signature
+    required: true
+    predicate_type: "https://slsa.dev/provenance/v1"
+    
+  - id: INV-L3-02
+    name: Attested (Model)
+    level: 3
+    assertion: "IF artifact.type == 'model' THEN attestations.model EXISTS"
+    formal: "ATTESTED(model) with metrics SIGNED"
+    description: Model attestation when artifact is ML model
+    required: conditional
+    condition: "artifact.type == 'model'"
+    
+  - id: INV-L3-03
+    name: Attested (Data)
+    level: 3
+    assertion: "IF uses_training_data THEN attestations.data EXISTS"
+    formal: "ATTESTED(data) with provenance SIGNED"
+    description: Data attestation when training data used
+    required: conditional
+    condition: "lineage.inputs[].role == 'training_data'"
+    
+  - id: INV-L3-04
+    name: Attested (Infrastructure)
+    level: 3
+    assertion: "attestations.infrastructure EXISTS"
+    formal: "ATTESTED(infrastructure) with security controls SIGNED"
+    description: Infrastructure security attestation
+    required: false  # Recommended
+    
+  - id: INV-L3-05
+    name: Policy Evaluated
+    level: 3
+    assertion: "policy.evaluations[].result ∈ {PASS, WARN}"
+    formal: "POLICY_EVALUATED with result"
+    description: Policy engine evaluation completed
+    required: true
+    
+  - id: INV-L3-06
+    name: Admission Gated
+    level: 3
+    assertion: "IF deploying THEN policy.admission_status.admitted == true"
+    formal: "ADMISSION_GATED for target environment"
+    description: Explicit admission decision for deployment
+    required: conditional
+    condition: "deploying_to_production"
+
+# ============================================================================
+# TOPOLOGY (Structural Complexity Options)
+# ============================================================================
+
+topology:
+  description: >
+    Organizations select lineage topology based on operational requirements.
+    Higher topology complexity enables richer provenance but requires more
+    sophisticated verification.
+  
+  options:
+    - id: TOPO-CHAIN
+      name: Chain
+      level: 1
+      description: Linear succession of artifacts
+      structure: "A → B → C → D"
+      max_inputs_per_artifact: 1
+      supports_branching: false
+      supports_merging: false
+      verification_complexity: "O(n)"
+      verification_algorithm: "pointer_traversal"
+      use_cases:
+        - Single artifact version history
+        - Sequential transformations
+        - Simple audit trails
+      schema_requirements:
+        - "lineage.previous_artifact_id: string | null"
+      
+    - id: TOPO-TREE
+      name: Tree
+      level: 2
+      description: Branching OR converging, but not both simultaneously
+      structure: |
+        Divergent:     Convergent:
+            A            A  B  C
+           / \            \ | /
+          B   C             D
+      max_inputs_per_artifact: "unlimited"
+      supports_branching: true
+      supports_merging: false  # No diamonds
+      verification_complexity: "O(n)"
+      verification_algorithm: "dfs_traversal"
+      use_cases:
+        - Team forks from base model
+        - Multi-input training pipelines
+        - Parallel experimentation
+      schema_requirements:
+        - "lineage.previous_artifact_id: string | null"
+        - "lineage.inputs: array"
+      
+    - id: TOPO-DAG
+      name: DAG (Directed Acyclic Graph)
+      level: 3
+      description: Full graph with diamond dependencies
+      structure: |
+            A
+           / \
+          B   C
+           \ /
+            D  ← diamond
+      max_inputs_per_artifact: "unlimited"
+      supports_branching: true
+      supports_merging: true
+      verification_complexity: "O(V+E)"
+      verification_algorithm: "toposort_with_diamond_check"
+      use_cases:
+        - Model merging
+        - Ensemble creation
+        - Federated learning
+        - Collaborative ML workflows
+      schema_requirements:
+        - "lineage.previous_artifact_id: string | null"
+        - "lineage.inputs: array"
+        - "lineage.merge_metadata: object"
+        - "lineage.topology: 'dag'"
+      additional_checks:
+        - "cycle_detection"
+        - "diamond_consistency"
+        - "multi_path_attestation_consistency"
+
+# ============================================================================
+# COMPONENTS
+# ============================================================================
+
+components:
+  - id: COMP-01
+    name: Artifact Registry
+    description: Storage for artifacts and their manifests
+    security_role: Stores WHAT with integrity
+    
+  - id: COMP-02
+    name: Signing Service
+    description: Key management and signature generation
+    security_role: Authenticates WHO produced artifact
+    
+  - id: COMP-03
+    name: Trust Store
+    description: Repository of trusted signer certificates
+    security_role: Validates signer identity (INV-L1-03)
+    
+  - id: COMP-04
+    name: Lineage Tracker
+    description: Tracks derivation relationships between artifacts
+    security_role: Enforces chain/tree/DAG integrity
+    
+  - id: COMP-05
+    name: Attestation Service
+    description: Generates and validates structured attestations
+    security_role: Provides evidence for claims (INV-L3-*)
+    
+  - id: COMP-06
+    name: Policy Engine
+    description: OPA/Rego-based policy evaluation
+    security_role: Enforces deployment gates (INV-L3-05)
+    
+  - id: COMP-07
+    name: Admission Controller
+    description: Kubernetes Gatekeeper or equivalent
+    security_role: Enforces production admission (INV-L3-06)
+
+# ============================================================================
+# RISKS
+# ============================================================================
+
+risks:
+  - id: RISK-01
+    name: Artifact Tampering
+    atlas_id: AML.T0048
+    stride: Tampering
+    description: Artifact content modified after signing
+    affected_levels: [1, 2, 3]
+    control: INV-L1-01
+    
+  - id: RISK-02
+    name: Provenance Forgery
+    atlas_id: AML.T0043
+    stride: Spoofing
+    description: False claims about artifact origin
+    affected_levels: [1, 2, 3]
+    controls: [INV-L1-02, INV-L1-03]
+    
+  - id: RISK-03
+    name: Lineage Manipulation
+    owasp_llm: LLM06
+    stride: Tampering
+    description: False derivation claims or input substitution
+    affected_levels: [2, 3]
+    controls: [INV-L2-01, INV-L2-02, INV-L2-04]
+    
+  - id: RISK-04
+    name: Chain Break
+    stride: Tampering
+    description: Hash chain integrity violated
+    affected_levels: [2, 3]
+    control: INV-L2-04
+    
+  - id: RISK-05
+    name: Diamond Inconsistency
+    description: Same artifact has different hashes via different paths
+    affected_levels: [3]
+    topology: TOPO-DAG
+    control: "diamond_consistency_check"
+    
+  - id: RISK-06
+    name: Attestation Forgery
+    atlas_id: AML.T0043
+    stride: Spoofing
+    description: False attestations about model/data/process
+    affected_levels: [3]
+    controls: [INV-L3-01, INV-L3-02, INV-L3-03]
+    
+  - id: RISK-07
+    name: Policy Bypass
+    stride: Elevation of Privilege
+    description: Deployment without required policy evaluation
+    affected_levels: [3]
+    controls: [INV-L3-05, INV-L3-06]
+    
+  - id: RISK-08
+    name: Signer Compromise
+    atlas_id: AML.T0024
+    stride: Spoofing
+    description: Signing key compromised
+    affected_levels: [1, 2, 3]
+    controls: [INV-L1-03]
+    mitigations:
+      - key_rotation
+      - hsm_storage
+      - certificate_revocation
+      
+  - id: RISK-09
+    name: Cycle Injection
+    stride: Tampering
+    description: Circular dependency introduced in DAG
+    affected_levels: [3]
+    topology: TOPO-DAG
+    control: "cycle_detection"
+    
+  - id: RISK-10
+    name: Multi-Party Claim Conflict
+    description: Different parties make inconsistent claims about same artifact
+    affected_levels: [2, 3]
+    control: "claim_consistency_check"
+
+# ============================================================================
+# CONTROLS
+# ============================================================================
+
+controls:
+  # Level 1 Controls
+  - id: CTRL-01
+    name: Hash Verification
+    implements: INV-L1-01
+    level: 1
+    description: Verify H(content) == digest
+    algorithm: "SHA256 | SHA384 | SHA512 | SHA3-256"
+    
+  - id: CTRL-02
+    name: Signature Verification
+    implements: INV-L1-02
+    level: 1
+    description: Verify signature over artifact manifest
+    algorithms: ["RS256", "ES256", "ES384", "EdDSA"]
+    
+  - id: CTRL-03
+    name: Trust Store Lookup
+    implements: INV-L1-03
+    level: 1
+    description: Verify signer exists in trust store
+    refresh_interval: "24h"
+    
+  - id: CTRL-04
+    name: Timestamp Validation
+    implements: [INV-L1-04, INV-L2-05]
+    level: 1
+    description: Verify timestamp within tolerance
+    l1_tolerance: 300
+    l2_tolerance: 60
+    source_preference: ["tsa", "local"]
+    
+  # Level 2 Controls
+  - id: CTRL-05
+    name: Input Hash Verification
+    implements: INV-L2-02
+    level: 2
+    description: Verify all input artifact hashes before derivation
+    critical: true
+    
+  - id: CTRL-06
+    name: Chain Signature Verification
+    implements: INV-L2-04
+    level: 2
+    description: Verify H(prev.signature) == chain_signature.previous_signature_hash
+    
+  - id: CTRL-07
+    name: Topology Validation
+    implements: [TOPO-CHAIN, TOPO-TREE, TOPO-DAG]
+    level: 2
+    description: Verify artifact structure matches declared topology
+    checks:
+      chain: "max_inputs == 1"
+      tree: "no_diamonds"
+      dag: "no_cycles"
+      
+  # Level 3 Controls
+  - id: CTRL-08
+    name: Attestation Signature Verification
+    implements: [INV-L3-01, INV-L3-02, INV-L3-03, INV-L3-04]
+    level: 3
+    description: Verify all attestation signatures
+    trust_level_required: "high"
+    
+  - id: CTRL-09
+    name: Policy Evaluation
+    implements: INV-L3-05
+    level: 3
+    description: Execute OPA/Rego policy rules
+    engine: "opa"
+    minimum_rules:
+      - artifact_integrity
+      - lineage_verified
+      - attestations_present
+      
+  - id: CTRL-10
+    name: Admission Gate
+    implements: INV-L3-06
+    level: 3
+    description: Verify admission status for target environment
+    controller: "gatekeeper"
+    
+  - id: CTRL-11
+    name: Diamond Consistency Check
+    implements: RISK-05
+    level: 3
+    topology: TOPO-DAG
+    description: Verify same artifact has consistent hash via all paths
+    
+  - id: CTRL-12
+    name: Cycle Detection
+    implements: RISK-09
+    level: 3
+    topology: TOPO-DAG
+    description: Verify no circular dependencies in graph
+    algorithm: "toposort"
+
+# ============================================================================
+# MATURITY LEVELS (Tiers)
+# ============================================================================
+
+maturity_levels:
+  - level: 1
+    name: Basic Integrity
+    description: "Proves: This artifact exists, was created by X, and hasn't changed"
+    required_invariants: [INV-L1-01, INV-L1-02, INV-L1-03]
+    optional_invariants: [INV-L1-04]
+    topology_options: [TOPO-CHAIN]
+    axioms_satisfied: [1, 2, 3, 4]  # From Zero-Trust Tool Invocation
+    
+    defaults:
+      hash_algorithm: SHA256
+      signature_algorithm: RS256
+      key_rotation_days: 90
+      timestamp_tolerance_seconds: 300
+      timestamp_required: false
+      trust_store_refresh_hours: 24
+      
+    anchor_points:
+      - field: "integrity._level2_anchor.chain_ready"
+        value: true
+      - field: "provenance._level2_anchor.inputs"
+        value: []
+      - field: "signature._level2_anchor.chain_position"
+        value: 0
+      - field: "signature._level2_anchor.previous_signature"
+        value: null
+        
+  - level: 2
+    name: Chaining and Lineage
+    description: "Proves: This artifact was derived from verified inputs through a documented process"
+    inherits: 1
+    required_invariants: [INV-L2-01, INV-L2-02, INV-L2-04, INV-L2-05]
+    optional_invariants: [INV-L2-03]
+    topology_options: [TOPO-CHAIN, TOPO-TREE]
+    axioms_satisfied: [1, 2, 3, 4, 5]  # Adds Hash Provenance
+    
+    defaults:
+      timestamp_tolerance_seconds: 60
+      timestamp_required: true
+      timestamp_source: tsa
+      max_chain_depth: 100
+      input_verification_required: true
+      process_parameters_hash_required: true
+      log_retention_days: 365
+      
+    derivation_claim_types:
+      - id: NULL_PROVENANCE
+        evidence_required: false
+        process_required: false
+      - id: VERIFICATION
+        evidence_required: false
+        process_required: false
+      - id: EVIDENCE_BACKED
+        evidence_required: true
+        process_required: true
+        
+    anchor_points:
+      - field: "_level3_anchor.attestation_slots"
+        value: []
+      - field: "_level3_anchor.policy_refs"
+        value: []
+        
+    conditional_requirements:
+      - condition: "classification.level <= 3"
+        requirements:
+          - "authorization.transport_binding REQUIRED"
+          - "audit.ticket_id REQUIRED"
+        
+  - level: 3
+    name: Attestations and Policy
+    description: "Proves: This artifact meets policy requirements and is approved for deployment"
+    inherits: 2
+    required_invariants: [INV-L3-01, INV-L3-05]
+    conditional_invariants: [INV-L3-02, INV-L3-03, INV-L3-06]
+    optional_invariants: [INV-L3-04]
+    topology_options: [TOPO-CHAIN, TOPO-TREE, TOPO-DAG]
+    axioms_satisfied: [1, 2, 3, 4, 5]  # Plus attestation proofs
+    
+    defaults:
+      signature_algorithm: ES384
+      required_attestation_categories: [process]
+      recommended_attestation_categories: [model, data, process, infrastructure]
+      attestation_predicate_type: "https://in-toto.io/attestation/v1"
+      provenance_predicate_type: "https://slsa.dev/provenance/v1"
+      attester_trust_level_for_production: high
+      policy_engine: opa
+      policy_format: rego
+      admission_controller: gatekeeper
+      evidence_retention_days: 2555
+      compliance_check_frequency: daily
+      
+    attestation_categories:
+      - category: process
+        required: always
+        claims:
+          required: [pipeline_version, execution_environment]
+          recommended: [slsa_level, reproducibility_score]
+      - category: model
+        required: when_type_is_model
+        claims:
+          required: [model_architecture, training_framework, performance_metrics]
+          recommended: [fairness_metrics, explainability_report]
+      - category: data
+        required: when_uses_training_data
+        claims:
+          required: [data_source, collection_date_range, record_count, schema_version]
+          recommended: [pii_scan_result, bias_analysis]
+      - category: infrastructure
+        required: recommended
+        claims:
+          required: [runtime_environment, security_controls]
+          recommended: [vulnerability_scan, sbom]
+
+# ============================================================================
+# VALIDATION SEQUENCE
+# ============================================================================
+
+validation_sequence:
+  level_1:
+    - step: 1
+      action: "VERIFY signature.algorithm ∈ allowed_algorithms"
+    - step: 2
+      action: "VERIFY signature over canonical manifest"
+      invariant: INV-L1-02
+    - step: 3
+      action: "VERIFY signer.subject ∈ trust_store"
+      invariant: INV-L1-03
+    - step: 4
+      action: "VERIFY H(artifact_content) == integrity.digest"
+      invariant: INV-L1-01
+      critical: true
+    - step: 5
+      action: "IF timestamp present: VERIFY |now() - signed_at| < tolerance"
+      invariant: INV-L1-04
+      optional: true
+    - step: 6
+      action: "RETURN {measured: true, produced_by: true, signer_verified: true}"
+      
+  level_2:
+    - step: 1-6
+      action: "[All Level 1 verification steps]"
+    - step: 7
+      action: "VERIFY lineage.chain_position > 0 OR chain_integrity == 'GENESIS'"
+    - step: 8
+      action: "FOR EACH input IN lineage.inputs: VERIFY H(input.content) == original_digest"
+      invariant: INV-L2-02
+      critical: true
+    - step: 9
+      action: "IF previous_artifact: VERIFY H(prev.signature) == previous_signature_hash"
+      invariant: INV-L2-04
+    - step: 10
+      action: "IF topology == TREE: VERIFY no_diamonds(graph)"
+    - step: 11
+      action: "IF derivation_claim.type == EVIDENCE_BACKED: VERIFY evidence exists"
+      invariant: INV-L2-03
+    - step: 12
+      action: "RETURN L1_results + {derived_from: true, inputs_verified: true, chain_valid: true}"
+      
+  level_3:
+    - step: 1-12
+      action: "[All Level 2 verification steps]"
+    - step: 13
+      action: "IF topology == DAG: VERIFY no_cycles(graph)"
+    - step: 14
+      action: "IF topology == DAG: VERIFY diamond_consistency(graph)"
+    - step: 15
+      action: "VERIFY attestations.process EXISTS AND signature valid"
+      invariant: INV-L3-01
+    - step: 16
+      action: "IF artifact.type == 'model': VERIFY attestations.model EXISTS"
+      invariant: INV-L3-02
+    - step: 17
+      action: "IF uses_training_data: VERIFY attestations.data EXISTS"
+      invariant: INV-L3-03
+    - step: 18
+      action: "FOR EACH evaluation IN policy.evaluations: VERIFY result ∈ {PASS, WARN}"
+      invariant: INV-L3-05
+    - step: 19
+      action: "IF deploying: VERIFY admission_status.admitted == true"
+      invariant: INV-L3-06
+    - step: 20
+      action: "RETURN L2_results + {attested: true, policy_passed: true, admitted: true}"
+
+# ============================================================================
+# FRAMEWORK MAPPINGS
+# ============================================================================
+
+framework_mappings:
+  mitre_atlas:
+    - id: AML.T0024
+      name: Session/Key Compromise
+      risks: [RISK-08]
+    - id: AML.T0040
+      name: Replay Attack
+      relevance: "Addressed by chain signatures"
+    - id: AML.T0043
+      name: Supply Chain Compromise
+      risks: [RISK-02, RISK-06]
+    - id: AML.T0048
+      name: Data Manipulation
+      risks: [RISK-01, RISK-03]
+      
+  owasp_llm_top10:
+    - id: LLM03
+      name: Training Data Poisoning
+      controls: [INV-L2-02, INV-L3-03]
+    - id: LLM06
+      name: Sensitive Information Disclosure
+      risks: [RISK-03]
+    - id: LLM08
+      name: Excessive Agency
+      controls: [INV-L3-05, INV-L3-06]
+      
+  stride:
+    - category: Spoofing
+      risks: [RISK-02, RISK-06, RISK-08]
+    - category: Tampering
+      risks: [RISK-01, RISK-03, RISK-04, RISK-09]
+    - category: Repudiation
+      controls: [INV-L1-02, INV-L2-03]
+    - category: Information Disclosure
+      controls: [CTRL-03]
+    - category: Denial of Service
+      relevance: "Out of scope"
+    - category: Elevation of Privilege
+      risks: [RISK-07]
+      
+  slsa:
+    - level: 1
+      description: "Documentation of build process"
+      mapped_to: INV-L2-03
+    - level: 2
+      description: "Tamper resistance of build service"
+      mapped_to: INV-L3-01
+    - level: 3
+      description: "Extra resistance to specific threats"
+      mapped_to: [INV-L3-01, INV-L3-04]
+    - level: 4
+      description: "Highest levels of confidence"
+      mapped_to: "maturity_level: 3 with all attestations"
+      
+  nist_ai_rmf:
+    - function: GOVERN
+      controls: [1.1, 1.2]
+      mapped_to: [INV-L3-05, INV-L3-06]
+    - function: MAP
+      controls: [3.1, 3.2]
+      mapped_to: [INV-L2-01, INV-L2-02]
+    - function: MEASURE
+      controls: [2.1, 2.2]
+      mapped_to: [INV-L3-02, INV-L3-03]
+    - function: MANAGE
+      controls: [1.1, 2.1]
+      mapped_to: [INV-L3-05]
+      
+  compliance:
+    - framework: SOC2
+      controls: [CC6.1, CC7.1, CC7.2]
+      evidence_sources: [attestations.process, attestations.infrastructure]
+    - framework: NIST-AI-RMF
+      functions: [GOVERN-1.1, MAP-3.1, MEASURE-2.1]
+      evidence_sources: [attestations.model, attestations.data]
+    - framework: ISO27001
+      controls: [A.12.1, A.14.2]
+      evidence_sources: [attestations.infrastructure, policy.evaluations]
+    - framework: PCI-DSS
+      requirements: [6.3, 6.5, 10.1]
+      evidence_sources: [audit, lineage, attestations.process]
+
+# ============================================================================
+# CROSS-PARTY CLAIM NAVIGATION
+# ============================================================================
+
+multi_party:
+  description: >
+    When claims come from different parties, navigation uses pointer-by-subject
+    indexing with independent signature verification per signer.
+    
+  claim_structure:
+    type: "Map<SubjectID, Set<SignedClaim>>"
+    example: |
+      claims["artifact-Y"] = {
+        SignedClaim(DERIVED_FROM, signer=Carol),
+        SignedClaim(ATTESTED:model, signer=Dave),
+        SignedClaim(ATTESTED:infra, signer=Eve),
+        SignedClaim(POLICY_EVALUATED, signer=Frank)
+      }
+      
+  verification_algorithm: |
+    def verify_multi_party(artifact_id, trust_policy):
+        claims = collect_claims_by_subject(artifact_id)
+        for claim in claims:
+            verify_signature(claim, claim.signer)
+            verify_signer_trusted(claim.signer, trust_policy)
+        for input_ref in get_input_references(claims):
+            verify_multi_party(input_ref.artifact_id, trust_policy)
+        assert has_required_claims(claims, artifact.maturity_level)
+        assert claims_consistent(claims)
+        
+  conflict_resolution:
+    strategies:
+      - id: FAIL
+        description: Any conflict fails verification
+      - id: QUORUM
+        description: Majority of trusted parties wins
+      - id: PRIORITY
+        description: Higher trust level wins
+      - id: TEMPORAL
+        description: Most recent claim wins (with caveats)

--- a/practical-guides/zero-trust-tool-invocation/zero-trust-pattern.md
+++ b/practical-guides/zero-trust-tool-invocation/zero-trust-pattern.md
@@ -1,0 +1,373 @@
+# Zero-Trust Tool Invocation Standard
+## Universal Metadata Layer for Secured Remote Execution
+
+**Version:** 1.2.0  
+**Status:** Draft  
+**Framework Alignment:** CoSAI-RM, MITRE ATLAS, OWASP Top 10 for LLM
+
+---
+
+## Abstract
+
+Tool invocation in agentic AI systems is remote code execution. This standard defines a **protocol-agnostic metadata layer** that cryptographically binds authorization to execution parameters, eliminating the vulnerability window between user intent and tool execution.
+
+The pattern works with—not against—existing protocols (MCP, AP2, OAuth 2.x) by providing a security envelope that any framework can implement.
+
+---
+
+## The Fundamental Problem
+
+```mermaid
+flowchart LR
+    subgraph traditional[" "]
+        A1[OAuth] --> A2[Token] --> A3["Tool(params*)"]
+    end
+    
+    subgraph zerotrust[" "]
+        B1[OAuth] --> B2["Token(H(params))"] --> B3[Tool]
+    end
+    
+    traditional ==>|bind| zerotrust
+
+    subgraph legend[" "]
+        L1["H = cryptographic hash"]
+        L2["· ad-hoc at approval (MCP)"]
+        L3["· pre-defined server-side (AP2/mandates)"]
+        L4["· PKI/DPoP optional transport binding"]
+    end
+
+    style traditional fill:none,stroke:#aaa,stroke-dasharray:3
+    style zerotrust fill:none,stroke:#333,stroke-width:2px
+    style legend fill:none,stroke:#ccc,stroke-dasharray:2
+```
+
+**The vulnerability:** Traditional authorization grants broad permissions. Parameters flow unvalidated from agent interpretation to tool execution.
+
+**The solution:** Cryptographic hash binding at authorization time. Parameters become immutable "code" that cannot be modified post-approval.
+
+---
+
+## Axioms
+
+### Axiom 1: Parameter Integrity
+```
+H(approved_params) == H(executed_params)
+```
+The hash of parameters approved by the user MUST equal the hash of parameters executed by the tool. Any deviation indicates tampering or misinterpretation.
+
+### Axiom 2: Atomic Consumption
+```
+consume(token.jti) → {success: once, failure: always}
+```
+Each authorization token MUST be consumable exactly once via atomic operation. Replay is impossible by construction.
+
+### Axiom 3: Temporal Binding
+```
+now() ∈ [token.nbf, token.exp]
+```
+Authorization is valid only within a defined temporal window. Default: 30 seconds.
+
+### Axiom 4: Identity Binding
+```
+token.sub == authenticated_user.id
+token.tool == requested_tool.name
+```
+The token MUST bind a specific identity to a specific tool. No delegation, no scope expansion.
+
+### Axiom 5: Hash Provenance (Protocol Agnostic)
+```
+H(params) := {
+  ad-hoc:      client-generated at user approval (MCP model)
+  pre-defined: server-generated at mandate definition (AP2 model)
+}
+```
+The hash MAY originate client-side or server-side. Both models satisfy parameter integrity when properly implemented.
+
+---
+
+## Components
+
+Following CoSAI-RM taxonomy:
+
+| Component | Description | Security Role |
+|-----------|-------------|---------------|
+| **Identity Provider** | OAuth 2.x / OIDC issuer | Authenticates WHO |
+| **Authorization Service** | Token generation with parameter binding | Binds WHAT to WHO |
+| **Atomic State Store** | Redis, etcd, DynamoDB | Enforces single-use (Axiom 2) |
+| **Validation Gateway** | Hash verification, temporal checks | Enforces Axioms 1, 3, 4 |
+| **Tool Endpoint** | Target execution environment | Executes only validated requests |
+
+---
+
+## Risks & Controls
+
+### Risk: Parameter Tampering (ATLAS: AML.T0048)
+**Threat:** Agent or MITM modifies parameters between approval and execution.  
+**Control:** Axiom 1 — Hash binding detects any modification.
+
+### Risk: Replay Attack (ATLAS: AML.T0040)
+**Threat:** Captured token reused for unauthorized execution.  
+**Control:** Axiom 2 — Atomic consumption; Axiom 3 — Temporal expiry.
+
+### Risk: Agent Misinterpretation (OWASP-LLM: LLM04)
+**Threat:** LLM regenerates different parameters than user intended.  
+**Control:** Axiom 1 — User-approved params hashed before agent processing.
+
+### Risk: Privilege Escalation (STRIDE: Elevation of Privilege)
+**Threat:** Token used for unintended tool or scope.  
+**Control:** Axiom 4 — Per-tool, per-identity binding.
+
+### Risk: Session Hijacking (ATLAS: AML.T0024)
+**Threat:** Long-lived token stolen and misused.  
+**Control:** Axiom 3 — 30-second TTL; Optional DPoP transport binding.
+
+---
+
+## Binding Modes
+
+### Mode A: Ad-Hoc Binding (MCP Model)
+Hash generated client-side at user approval time.
+
+```
+User approves params → Client computes H(params) → Token(H) issued → Tool validates H
+```
+
+**Use case:** Interactive approvals, human-in-the-loop workflows.
+
+### Mode B: Pre-Defined Binding (AP2/Mandate Model)  
+Hash generated server-side at mandate definition time.
+
+```
+Admin defines mandate → Server computes H(allowed_params) → Token(H) issued → Tool validates H
+```
+
+**Use case:** Automated workflows, pre-approved operation sets.
+
+### Mode C: Hybrid
+Server defines parameter schema; client binds specific values within schema.
+
+```
+Server: H(schema) → Client: H(schema + values) → Token(H_combined) → Tool validates
+```
+
+**Use case:** Constrained flexibility with guardrails.
+
+---
+
+## Metadata Schema (v1.1)
+
+### Required Fields
+
+```yaml
+transaction:
+  id: string          # Unique transaction identifier
+  timestamp: ISO-8601 # Request initiation time
+
+identity:
+  sub: string         # User identifier (from OAuth)
+  provider: string    # Identity provider identifier
+
+action:
+  tool: string        # Tool/operation identifier
+  parameters_hash: string  # H(params), hex-encoded
+  binding_mode: enum  # "ad-hoc" | "pre-defined" | "hybrid"
+
+authorization:
+  token: string       # Ephemeral JWT
+  expires_at: ISO-8601
+  jti: string         # Unique token ID for atomic consumption
+```
+
+### Optional Fields
+
+```yaml
+transport:
+  dpop_proof: string      # DPoP JWT for transport binding
+  tls_fingerprint: string # Certificate fingerprint
+
+classification:
+  level: integer      # 1-5, per data sensitivity
+  requires: array     # ["ephemeral_token", "dpop", "audit"]
+
+provenance:
+  hash_origin: enum   # "client" | "server"
+  hash_algorithm: string  # "SHA256" | "SHA3-512"
+```
+
+---
+
+## Validation Sequence
+
+```
+1. VERIFY token signature
+2. ASSERT token.sub == authenticated_user.id        [Axiom 4]
+3. ASSERT token.tool == requested_tool              [Axiom 4]  
+4. ASSERT now() < token.exp                         [Axiom 3]
+5. ASSERT H(request.params) == token.parameters_hash [Axiom 1]
+6. ASSERT atomic_consume(token.jti) == success      [Axiom 2]
+7. IF dpop_present: VERIFY dpop_proof binds to token
+8. EXECUTE tool(params)
+9. LOG transaction for audit
+```
+
+Step 5 is the critical differentiator from traditional OAuth. Steps 1-4, 6 are standard JWT validation with atomic consumption.
+
+---
+
+## Framework Mappings
+
+| Standard | Reference | Coverage |
+|----------|-----------|----------|
+| **MITRE ATLAS** | AML.T0024, AML.T0040, AML.T0048 | Session hijacking, replay, tampering |
+| **OWASP LLM Top 10** | LLM04, LLM06, LLM08 | Prompt injection, sensitive disclosure, excessive agency |
+| **NIST AI RMF** | GOVERN 1.1, MAP 3.1, MEASURE 2.1 | Risk governance, threat identification, monitoring |
+| **STRIDE** | Spoofing, Tampering, Repudiation, Elevation | Full coverage via axioms |
+
+---
+
+## Differentiation from RFC 9396 (RAR)
+
+| Aspect | RFC 9396 RAR | This Standard |
+|--------|--------------|---------------|
+| **Parameter Binding** | Pre-registered types | Ad-hoc or pre-defined hash |
+| **Server Requirements** | Maintain parameter registry | Validate hash match |
+| **Flexibility** | Limited to registered schemas | Any parameter combination |
+| **Complexity** | Schema definition overhead | Hash computation only |
+
+**Key insight:** RAR transmits semantics for server validation. This standard transmits commitments for hash verification. The server need not understand parameters—only verify integrity.
+
+---
+
+## Implementation Tiers
+
+### Tier 1: Minimum Viable (Class 4-5 tools)
+- Ephemeral tokens (30s TTL)
+- Parameter hash in token claims
+- Atomic JTI consumption
+- Hash validation on execution
+
+### Tier 2: Enhanced (Class 2-3 tools)
+- Tier 1 requirements
+- DPoP transport binding
+- Comprehensive audit logging
+- Classification-based routing
+
+### Tier 3: Maximum (Class 1 tools)
+- Tier 2 requirements
+- Client-side pre-signing
+- Certificate pinning
+- Hardware-backed key storage
+
+---
+
+## Vendor Integration Checklist
+
+```yaml
+minimum_viable:
+  - [ ] Generate ephemeral tokens with ≤30s TTL
+  - [ ] Include parameters_hash in token claims
+  - [ ] Implement atomic JTI consumption
+  - [ ] Validate H(request.params) == token.parameters_hash
+  - [ ] Return structured error responses
+
+enhanced:
+  - [ ] Support DPoP proof validation
+  - [ ] Implement binding_mode field
+  - [ ] Add classification-based controls
+  - [ ] Comprehensive audit trail
+
+maximum:
+  - [ ] Require client signatures
+  - [ ] Support pre-defined hash mode
+  - [ ] Certificate/key pinning
+  - [ ] HSM integration for signing keys
+```
+
+---
+
+## Security Guarantees
+
+When all axioms are satisfied:
+
+1. **Integrity:** Executed parameters == approved parameters
+2. **Authenticity:** Request originates from authenticated identity
+3. **Non-replayability:** Each authorization usable exactly once
+4. **Temporal containment:** Exposure window ≤ 30 seconds
+5. **Protocol independence:** Works with MCP, AP2, OAuth, custom protocols
+
+---
+
+## References
+
+- [CoSAI Risk Map](https://github.com/cosai-oasis/cosai-rm)
+- [MITRE ATLAS](https://atlas.mitre.org/)
+- [OWASP Top 10 for LLM](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [RFC 9449 - OAuth 2.0 DPoP](https://datatracker.ietf.org/doc/html/rfc9449)
+- [RFC 9396 - OAuth 2.0 RAR](https://datatracker.ietf.org/doc/html/rfc9396)
+
+---
+
+## Appendix A: Six Cryptographic Invariants
+
+| # | Invariant | Assertion | Tier |
+|---|-----------|-----------|------|
+| 1 | **Identity-Tool Binding** | `token.sub == user.id AND token.tool == request.tool` | 1 |
+| 2 | **Temporal Validity** | `now() < token.exp AND now() >= token.nbf` | 1 |
+| 3 | **Parameter Integrity** | `sha256(actualParams) == token.parameters_hash` | 1 |
+| 4 | **Atomic Consumption** | `atomicStore.compareAndSet(jti, null, "consumed")` | 1 |
+| 5 | **Transport Binding (DPoP)** | `verify(dpopProof) AND sha256(token) == ath` | 2 |
+| 6 | **Client Signature (Enhanced)** | `verify(invocationSignature, clientPublicKey)` | 3 |
+
+**Invariant 3 is the critical differentiator.** Traditional OAuth validates identity; this standard validates intent.
+
+### Invariant Dependency Graph
+
+```
+Tier 1 (Required)          Tier 2 (Enhanced)       Tier 3 (Maximum)
+─────────────────          ─────────────────       ────────────────
+[1] Identity-Tool ─┐
+[2] Temporal      ─┼──→ [5] Transport (DPoP) ──→ [6] Client Signature
+[3] Parameter     ─┤
+[4] Atomic        ─┘
+```
+
+Tier 1 invariants are mandatory for all implementations. Tier 2+ are additive based on data classification.
+```mermaid
+graph TD
+    subgraph "Interdiction Layer"
+        A[Client Extensions<br/>Browser/IDE Plugins<br/>👤 WHO] -->|Local Session| B[Reverse Proxy<br/>Traffic Gateway<br/>📍 WHERE]
+        B -->|Session Telemetry| C[Policy Engine<br/>Decision Point<br/>📋 WHAT]
+        C -->|Rule Evaluation| D[Validation Framework<br/>Rail Execution<br/>⚙️ HOW]
+    end
+    
+    subgraph "Metadata Requirements"
+        E[Regulatory Context<br/>Compliance Rules<br/>❓ WHY]
+        F[Data Sensitivity<br/>Classification Level<br/>📋 WHAT]
+        G[Contextual State<br/>Retrieved Knowledge<br/>⚙️ HOW]
+    end
+    
+    E --> C
+    F --> C
+    G --> D
+
+    classDef interdiction fill:#e1f5ff,stroke:#0288d1,stroke-width:2px
+    classDef metadata fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+    
+    class A,B,C,D interdiction
+    class E,F,G metadata
+```
+
+### Comparative Vulnerability Matrix
+
+| Attack Vector | Threat Category | Traditional Auth<br/>(OAuth 2.0 + RBAC) | Zero-Trust MCP<br/>(Base Pattern) | Zero-Trust MCP<br/>(Enhanced w/ CoC) |
+|--------------|:---------------:|-----------------|----------------|---------------------------|
+| **Parameter Tampering**<br/><sub>Attacker modifies parameters between authorization and execution</sub> | **MCP-T5**<br/><sub>Insufficient Integrity Checks</sub> | ❌ Vulnerable<br/><sub>(Session binding only, params not validated)</sub> | ✅ Protected<br/><sub>**Invariant #2**: SHA256 hash binding</sub> | ✅ Protected<br/><sub>**Invariants #2 + #5**: Hash + breadcrumb chain</sub> |
+| **Replay Attacks**<br/><sub>Attacker reuses captured authorization tokens</sub> | **MCP-T1**<br/><sub>Replay Attacks / Session Hijacking</sub> | ❌ Vulnerable<br/><sub>(Tokens valid for minutes/hours)</sub> | ✅ Protected<br/><sub>**Invariant #3**: Atomic JTI consumption</sub> | ✅ Protected<br/><sub>**Invariants #3 + #6**: Atomic + cryptographic proof</sub> |
+| **Token/Session Hijacking**<br/><sub>Attacker steals and uses valid tokens</sub> | **MCP-T1**<br/><sub>Credential/Token Theft<br/>Session Token Leakage</sub> | ❌ Vulnerable<br/><sub>(Long-lived tokens, broad scope)</sub> | ✅ Protected<br/><sub>**Invariants #1 + #4**: 30s TTL + per-action binding</sub> | ✅ Protected<br/><sub>**Invariants #1 + #4 + #6**: 30s TTL + audit chain</sub> |
+| **Agent Misinterpretation**<br/><sub>LLM regenerates different parameters than user intended</sub> | **MCP-T10**<br/><sub>Overreliance on LLM</sub><br/>**MCP-T3**<br/><sub>Prompt Injection</sub> | ❌ Vulnerable<br/><sub>(LLM free to regenerate params)</sub> | ✅ Protected<br/><sub>**Invariant #2**: Hash validates human-approved params</sub> | ✅ Protected<br/><sub>**Invariant #2**: Hash validates human-approved params</sub> |
+| **Parameter Injection**<br/><sub>Attacker injects malicious parameters via prompt injection</sub> | **MCP-T3**<br/><sub>Command Injection</sub><br/>**MCP-T5**<br/><sub>Input Validation Failure</sub> | ❌ Vulnerable<br/><sub>(No param validation at auth time)</sub> | ✅ Protected<br/><sub>**Invariant #2**: Pre-authorization hashing</sub> | ✅ Protected<br/><sub>**Invariant #2**: Pre-authorization hashing</sub> |
+| **Race Conditions**<br/><sub>Concurrent token use or state manipulation</sub> | **MCP-T2**<br/><sub>TOCTOU</sub> | ❌ Vulnerable<br/><sub>(No atomic state management)</sub> | ✅ Protected<br/><sub>**Invariant #3**: Atomic store (Redis/etcd)</sub> | ✅ Protected<br/><sub>**Invariant #3**: Atomic store (Redis/etcd)</sub> |
+| **TOCTOU Attacks**<br/><sub>Time-of-check to time-of-use vulnerabilities</sub> | **MCP-T2**<br/><sub>TOCTOU</sub> | ❌ Vulnerable<br/><sub>(Async validation, stale state)</sub> | ✅ Protected<br/><sub>**Invariant #4**: Real-time validation (<30s)</sub> | ✅ Protected<br/><sub>**Invariant #4**: Real-time validation (<30s)</sub> |
+| **Privilege Escalation**<br/><sub>Attacker uses authorized action for unintended purpose</sub> | **MCP-T2**<br/><sub>Privilege Escalation<br/>Excessive Permissions</sub> | ❌ Vulnerable<br/><sub>(Coarse RBAC, role confusion)</sub> | ✅ Protected<br/><sub>**Invariant #1**: Per-tool granular binding</sub> | ✅ Protected<br/><sub>**Invariants #1 + #6**: Per-tool + audit trail</sub> |
+| **Config Tampering**<br/><sub>Policy engine compromised after authorization</sub> | **MCP-T4**<br/><sub>Missing Integrity Verification</sub><br/>**MCP-T5**<br/><sub>Insufficient Integrity Checks</sub> | ❌ Not addressed<br/><sub>(No config integrity checks)</sub> | ⚠️ Detected<br/><sub>(Audit logs show changes)</sub> | ✅ Protected<br/><sub>**Invariant #5**: Breadcrumb chain validation</sub> |
+| **Chain of Custody Breaks**<br/><sub>Authorization trail becomes non-verifiable</sub> | **MCP-T11**<br/><sub>Lack of Observability</sub><br/>**MCP-T4**<br/><sub>Missing Integrity Verification</sub> | ❌ Not provided<br/><sub>(No cryptographic trail)</sub> | ⚠️ Partial<br/><sub>(Audit logs only, no crypto proof)</sub> | ✅ Protected<br/><sub>**Invariant #6**: Cryptographic chain</sub> |

--- a/practical-guides/zero-trust-tool-invocation/zero-trust-tool-invocation.schema.yaml
+++ b/practical-guides/zero-trust-tool-invocation/zero-trust-tool-invocation.schema.yaml
@@ -1,0 +1,250 @@
+# Zero-Trust Tool Invocation - CoSAI-RM Schema
+# Version: 1.2.0
+
+metadata:
+  name: zero-trust-tool-invocation
+  version: "1.2.0"
+  status: draft
+  framework_mappings:
+    - cosai-rm
+    - mitre-atlas
+    - owasp-llm-top10
+    - nist-ai-rmf
+    - stride
+
+invariants:
+  - id: INV-1
+    name: Identity-Tool Binding
+    assertion: "token.sub == user.id AND token.tool == request.tool"
+    description: Token binds specific identity to specific tool
+    tier: 1
+    required: true
+    
+  - id: INV-2
+    name: Temporal Validity
+    assertion: "now() < token.exp AND now() >= token.nbf"
+    description: Authorization valid only within defined temporal window
+    tier: 1
+    required: true
+    default_ttl_seconds: 30
+    
+  - id: INV-3
+    name: Parameter Integrity
+    assertion: "sha256(actualParams) == token.parameters_hash"
+    description: Hash of executed parameters must equal hash bound in token
+    tier: 1
+    required: true
+    critical: true  # Differentiator from traditional OAuth
+    
+  - id: INV-4
+    name: Atomic Consumption
+    assertion: "atomicStore.compareAndSet(jti, null, 'consumed')"
+    description: Authorization token consumable exactly once
+    tier: 1
+    required: true
+    
+  - id: INV-5
+    name: Transport Binding (DPoP)
+    assertion: "verify(dpopProof) AND sha256(token) == ath"
+    description: Binds token to TLS session via proof-of-possession
+    tier: 2
+    required: false
+    
+  - id: INV-6
+    name: Client Signature (Enhanced)
+    assertion: "verify(invocationSignature, clientPublicKey)"
+    description: Client pre-signs complete invocation for non-repudiation
+    tier: 3
+    required: false
+
+hash_provenance:
+  description: Hash may originate client-side or server-side
+  modes:
+    - id: ad-hoc
+      description: Client-generated at user approval (MCP model)
+    - id: pre-defined
+      description: Server-generated at mandate definition (AP2 model)
+    - id: hybrid
+      description: Server schema + client values
+
+components:
+  - id: COMP-01
+    name: Identity Provider
+    description: OAuth 2.x / OIDC issuer
+    security_role: Authenticates WHO
+    
+  - id: COMP-02
+    name: Authorization Service
+    description: Token generation with parameter binding
+    security_role: Binds WHAT to WHO
+    
+  - id: COMP-03
+    name: Atomic State Store
+    description: Redis, etcd, DynamoDB with atomic operations
+    security_role: Enforces single-use (AXIOM-2)
+    
+  - id: COMP-04
+    name: Validation Gateway
+    description: Hash verification, temporal checks
+    security_role: Enforces AXIOM-1, AXIOM-3, AXIOM-4
+    
+  - id: COMP-05
+    name: Tool Endpoint
+    description: Target execution environment
+    security_role: Executes only validated requests
+
+risks:
+  - id: RISK-01
+    name: Parameter Tampering
+    atlas_id: AML.T0048
+    owasp_llm: LLM04
+    stride: Tampering
+    description: Agent or MITM modifies parameters between approval and execution
+    control: INV-3
+    
+  - id: RISK-02
+    name: Replay Attack
+    atlas_id: AML.T0040
+    stride: Spoofing
+    description: Captured token reused for unauthorized execution
+    controls: [INV-4, INV-2]
+    
+  - id: RISK-03
+    name: Agent Misinterpretation
+    owasp_llm: LLM04
+    description: LLM regenerates different parameters than user intended
+    control: INV-3
+    
+  - id: RISK-04
+    name: Privilege Escalation
+    stride: Elevation of Privilege
+    description: Token used for unintended tool or scope
+    control: INV-1
+    
+  - id: RISK-05
+    name: Session Hijacking
+    atlas_id: AML.T0024
+    stride: Spoofing
+    description: Long-lived token stolen and misused
+    controls: [INV-2, INV-5]
+
+controls:
+  - id: CTRL-01
+    name: Identity-Tool Validation
+    implements: INV-1
+    tier: 1
+    description: Verify token.sub and token.tool match request
+    
+  - id: CTRL-02
+    name: Temporal Validation
+    implements: INV-2
+    tier: 1
+    description: Verify token within validity window
+    
+  - id: CTRL-03
+    name: Hash Binding
+    implements: INV-3
+    tier: 1
+    description: Validate sha256(request.params) == token.parameters_hash
+    critical: true
+    
+  - id: CTRL-04
+    name: Atomic JTI Consumption
+    implements: INV-4
+    tier: 1
+    description: Single-use token via atomic store operation
+    
+  - id: CTRL-05
+    name: DPoP Transport Binding
+    implements: INV-5
+    tier: 2
+    description: Bind token to TLS session via proof-of-possession
+    optional: true
+    
+  - id: CTRL-06
+    name: Client Pre-Signing
+    implements: INV-6
+    tier: 3
+    description: Client signs complete invocation
+    optional: true
+
+tiers:
+  - level: 1
+    name: Minimum Viable
+    classification: [4, 5]
+    required_invariants: [INV-1, INV-2, INV-3, INV-4]
+    
+  - level: 2
+    name: Enhanced
+    classification: [2, 3]
+    required_invariants: [INV-1, INV-2, INV-3, INV-4, INV-5]
+    
+  - level: 3
+    name: Maximum
+    classification: [1]
+    required_invariants: [INV-1, INV-2, INV-3, INV-4, INV-5, INV-6]
+
+validation_sequence:
+  - step: 1
+    action: VERIFY token signature
+  - step: 2
+    action: ASSERT token.sub == authenticated_user.id
+    invariant: INV-1
+  - step: 3
+    action: ASSERT token.tool == requested_tool
+    invariant: INV-1
+  - step: 4
+    action: ASSERT now() < token.exp AND now() >= token.nbf
+    invariant: INV-2
+  - step: 5
+    action: ASSERT sha256(request.params) == token.parameters_hash
+    invariant: INV-3
+    critical: true
+  - step: 6
+    action: ASSERT atomicStore.compareAndSet(jti, null, "consumed")
+    invariant: INV-4
+  - step: 7
+    action: IF dpop_present THEN verify(dpopProof) AND sha256(token) == ath
+    invariant: INV-5
+    optional: true
+  - step: 8
+    action: IF signature_present THEN verify(invocationSignature, clientPublicKey)
+    invariant: INV-6
+    optional: true
+  - step: 9
+    action: EXECUTE tool(params)
+  - step: 10
+    action: LOG transaction
+
+framework_mappings:
+  mitre_atlas:
+    - id: AML.T0024
+      name: Session Hijacking
+      risks: [RISK-05]
+    - id: AML.T0040
+      name: Replay Attack
+      risks: [RISK-02]
+    - id: AML.T0048
+      name: Data Manipulation
+      risks: [RISK-01]
+      
+  owasp_llm_top10:
+    - id: LLM04
+      name: Model Denial of Service / Prompt Injection
+      risks: [RISK-01, RISK-03]
+    - id: LLM06
+      name: Sensitive Information Disclosure
+      controls: [CTRL-01]
+    - id: LLM08
+      name: Excessive Agency
+      controls: [CTRL-04]
+      
+  stride:
+    - category: Spoofing
+      risks: [RISK-02, RISK-05]
+    - category: Tampering
+      risks: [RISK-01]
+    - category: Repudiation
+      controls: [CTRL-06]
+    - category: Elevation of Privilege
+      risks: [RISK-04]


### PR DESCRIPTION
Restores the four files that were previously reverted from the root directory, relocating them into a new, structured `practical-guides/` directory. The content remains byte-identical to the original commit, with the exception of the filename change for `artifact-integrity-maturity.cosai-rm.yaml` to match the correct extension.