### PR TITLE
Add AI Usage Policy section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,117 @@ If you have questions about the contribution process, please reach out through o
 
 ## AI Usage Policy
 
+This workstream produces guidance for *secure* agentic systems, so we hold
+contributions made with AI assistance to the same standard we ask others to
+hold theirs. AI tools are welcome — many maintainers use them — but the
+following rules apply to every contribution, regardless of who submits it.
+
+This policy operates within the framework of the [OASIS CoSAI AI Usage Guidelines](https://github.com/cosai-oasis/oasis-open-project/blob/main/AI-USAGE-GUIDELINES.md),
+which set the baseline for all CoSAI workstreams. Where this document is
+more specific, it adds workstream-specific expectations on top of that
+baseline; where it is silent, the parent guidelines govern.
+
+### Engagement before contribution
+
+This workstream's effort is directed by approved RFCs and prioritized issues.
+Contributions are welcome when they land within work the working group has
+already scoped and agreed to — not as unsolicited proposals dropped into the
+PR queue.
+
+Unsolicited "drive-by" pull requests, large code or document donations not
+linked to an approved RFC, and AI-assisted contributions submitted without
+prior engagement on the issue tracker, mailing list, or Slack channel may be
+closed without review. This applies regardless of how the work was produced;
+AI tools make it inexpensive to generate volume, which makes alignment with
+the working group's scope the load-bearing step, not the writing.
+
+If you have an idea you want to contribute, start by:
+
+1. Opening an issue or [RFC](rfc-template.md) describing the problem and
+   proposed approach.
+2. Engaging on the [Slack channel](https://cosai-op.slack.com/archives/C08ET0T8L57)
+   or [mailing list](mailto:cosai-agentic-systems-ws@lists.oasis-open-projects.org)
+   so the working group can weigh in *before* substantial work is invested.
+
+This is the same expectation the [Pull Request Guidelines](#pull-request-guidelines)
+above set for all contributions; we restate it here because AI assistance
+changes the economics of producing PRs, not the economics of reviewing them.
+
+### Disclosure
+
+This workstream follows the CoSAI-wide convention for attributing AI
+assistance, originating from
+[secure-ai-tooling#149](https://github.com/cosai-oasis/secure-ai-tooling/issues/149):
+
+- **Use the standard vendor-neutral trailer in commit messages** when a
+  commit was produced with AI assistance:
+
+  ```
+  Co-authored-by: AI Assistant <ai-assistant@coalitionforsecureai.org>
+  ```
+
+  This matches the existing `Co-authored-by:` convention for human
+  collaborators. Naming specific AI vendors or models in commit attribution
+  is discouraged — see the linked issue for rationale (avoiding the
+  appearance of endorsement or friction in a multi-org coalition).
+
+- **For substantial AI assistance** — for example, AI drafted a section,
+  generated structured content, or produced more than a brief edit —
+  additionally describe the assistance in the PR or issue body: what the
+  tool helped with and at what stage of drafting. This is consistent with
+  the OASIS CoSAI AI Usage Guidelines' call for transparency about
+  substantial use of AI systems.
+
+- A `prepare-commit-msg` hook for adding the trailer automatically is
+  documented in
+  [secure-ai-tooling#149](https://github.com/cosai-oasis/secure-ai-tooling/issues/149).
+
+### Human accountability
+
+- **You must understand what you submit.** If you cannot explain what your
+  contribution says or does, and how it fits into the surrounding work,
+  without the aid of an AI tool, do not submit it. Reviewers will ask, and
+  the workstream relies on contributors being able to defend their reasoning.
+- **Human-in-the-loop review is required for AI-assisted text.** Any AI-drafted
+  prose in issues, discussions, or PRs must be read and edited by a human
+  before submission. AI output tends toward verbosity and surface plausibility;
+  trimming and verification are the contributor's responsibility.
+- **Treat AI output as a starting point, not a finished artefact.** Per the
+  [OASIS CoSAI AI Usage Guidelines](https://github.com/cosai-oasis/oasis-open-project/blob/main/AI-USAGE-GUIDELINES.md),
+  substantial use of AI in drafting is expected to be iterative — multiple
+  rounds of human review and refinement before submission, not a single-pass
+  paste from a generation tool.
+
+### Scope and limits
+
+- **Text and code only.** AI-generated images, diagrams, audio, or video are
+  not accepted. Diagrams should be hand-authored (e.g. Mermaid, draw.io,
+  hand-drawn) so that the design intent is auditable.
+- **Choice of tools.** CoSAI does not endorse or require any specific AI
+  vendor. Editors are encouraged to vary tools across contributions, both to
+  avoid the appearance of favoring a single vendor and to keep the
+  workstream's outputs from depending on any one tool's idiosyncrasies.
+
+### Intellectual property
+
+- **You are responsible for the IP status of what you contribute.** It is
+  the contributor's responsibility to confirm that any AI-generated content
+  they submit may be redistributed under this repository's licenses
+  (CC-BY 4.0 for documents, Apache 2.0 for code) and donated to OASIS under
+  the [OASIS Open Projects rules](https://www.oasis-open.org/policies-guidelines/open-projects-process/).
+  Contributors should prefer reputable AI systems with clear terms regarding
+  output ownership and training-data provenance.
+
+### Why this policy exists
+
+This is a public OASIS Open Project producing security guidance that
+downstream users will rely on. Low-effort, AI-generated submissions push
+review burden onto maintainers and undermine the workstream's credibility.
+The bar is not "no AI" — it is "a human who understands the work, and who
+has engaged with the working group on what's worth doing, stands behind
+every contribution."
+
+*This policy draws on the [Ghostty project's AI Usage Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md)
+as prior art, with thanks; it has been adapted for the OASIS open-standards
+context and the specific governance of this workstream.*
+


### PR DESCRIPTION
## Summary

Fills in the previously empty `## AI Usage Policy` heading at the bottom of `CONTRIBUTING.md` (added in 1f5d59a). The new section covers:

- **Engagement before contribution** — making explicit that drive-by PRs and unsolicited AI-assisted donations not aligned with an approved RFC or issue may be closed without review.
- **Disclosure** — uses the CoSAI-wide vendor-neutral `Co-authored-by: AI Assistant <ai-assistant@coalitionforsecureai.org>` trailer in commit messages (per [secure-ai-tooling#149](https://github.com/cosai-oasis/secure-ai-tooling/issues/149), adopted as default), with richer per-PR disclosure for substantial AI use.
- **Human accountability** — contributors must understand what they submit, AI-drafted prose requires human review/editing, and AI output is treated as an iterative starting point rather than a finished artefact.
- **Scope and limits** — text and code only (no AI-generated media); CoSAI does not endorse a specific vendor and editors are encouraged to vary tools.
- **Intellectual property** — restates the IP-responsibility language from the existing CoSAI whitepaper template, scoped to AI output and the OASIS donation rules.
- **Why this policy exists** — short rationale paragraph.

## Alignment with upstream CoSAI documents

The section operates within the framework of the [OASIS CoSAI AI Usage Guidelines](https://github.com/cosai-oasis/oasis-open-project/blob/main/AI-USAGE-GUIDELINES.md) and explicitly says so up top — that doc sets the baseline for all CoSAI workstreams; this WS4 policy adds workstream-specific expectations on top.

The Disclosure subsection follows the CoSAI-wide vendor-neutral attribution convention from [secure-ai-tooling#149](https://github.com/cosai-oasis/secure-ai-tooling/issues/149) (closed as adopted default). Naming specific AI vendors in commit attribution is discouraged to avoid the appearance of endorsement or friction in a multi-org coalition.

## Prior art

The structural framing is adapted from the [Ghostty project's AI Usage Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md), with credit. Adjustments for the OASIS context: the denouncement-list mechanism and maintainer exemption were dropped, the tone was rewritten to a neutral standards-body register, and the existing CoSAI IP-and-vendor language was folded in.

Targets the `reorg` branch since that's where the empty `## AI Usage Policy` heading was introduced.

## AI assistance disclosure

Per the policy this PR introduces, this PR was drafted with substantial AI assistance (Claude Code, Opus 4.7). Claude proposed the section structure, drafted the prose, audited it against the two upstream CoSAI documents linked above, and applied edits based on iterative direction (drop the denouncement list and maintainer exemption, keep the engagement-before-contribution emphasis, neutral OASIS register, switch to vendor-neutral attribution after upstream-doc audit, add iterative-refinement principle from the parent guidelines, acknowledge Ghostty as prior art). I reviewed each draft, directed the edits, and stand behind the final text.

The commit on this branch uses the vendor-neutral `Co-authored-by: AI Assistant <ai-assistant@coalitionforsecureai.org>` trailer that this PR is introducing.

## Test plan

- [ ] Reviewers read the new section end-to-end and confirm tone aligns with OASIS/CoSAI register.
- [ ] Confirm cross-link to `#pull-request-guidelines` resolves (anchor matches the existing `## Pull Request Guidelines` heading).
- [ ] Confirm relative link to `rfc-template.md` resolves on the `reorg` branch.
- [ ] Confirm the vendor-neutral attribution alignment with [secure-ai-tooling#149](https://github.com/cosai-oasis/secure-ai-tooling/issues/149) is what WS4 wants to adopt (the issue's resolution applied to `secure-ai-tooling`; this PR propagates the convention to WS4).
- [ ] Decide whether the maintainer-exemption question (dropped here) is something we want to address explicitly elsewhere in governance docs, or leave silent.
- [ ] Decide whether the "no AI-generated media" rule (stricter than the parent guidelines, which are silent) is what WS4 wants.