### PR TITLE
feat: Add SIG for Agent Development Lifecycle (ADLC)

### DIFF
--- a/SIGs/ADLC/README.md
+++ b/SIGs/ADLC/README.md
@@ -1,0 +1,19 @@
+# SIG: Agent Development Lifecycle (ADLC)
+
+This SIG is part of [CoSAI Workstream 4, Secure Design Patterns for Agentic Systems](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems). CoSAI is an [OASIS Open Project](https://www.oasis-open.org/open-projects/) and an open ecosystem of AI and security experts from industry leading organizations dedicated to sharing best practices for secure AI deployment and collaborating on AI security research and product development. For more information on CoSAI, please visit the [CoSAI website](https://www.coalitionforsecureai.org/) and the [Open Project repository](https://github.com/cosai-oasis/oasis-open-project) which has information regarding the governance, sponsors and rosters and the project charter.
+
+### About this SIG
+The goal of this SIG is to research and develop secure lifecycle practices for AI-based agentic systems. This SIG addresses the infrastructure, identity, lifecycle, and operational security of the agents themselves. The SIG focuses on providing quick, tangible ways to more securely deploy agent development ecosystems, reducing the risk of failures while enabling organizations to make explicit, informed choices. Among its deliverables, this SIG will produce a comprehensive Agent Development Lifecycle (ADLC) document that defines trust boundaries across the entire agent lifecycle, identifies the controls needed at each phase, the prerequisites for those controls, and the risks that arise when they are absent.
+
+### SIG Leads
+* Jennings Aske (SailPoint)
+* Kathleen Goeschel (Red Hat)
+* Parul Singh (Red Hat)
+
+### Deliverables
+
+*TBD*
+
+### Contributing
+
+Check out our [onboarding guidance for new participants](https://github.com/cosai-oasis/oasis-open-project/blob/main/ONBOARDING.md) and please see the [CoSAI Contributing policy](../../CONTRIBUTING.md) for more details.


### PR DESCRIPTION
## Summary
- Adds `SIGs/ADLC/README.md` — the initial proposal for the Agent Development Lifecycle (ADLC) Special Interest Group
- Defines the SIG mission: secure lifecycle practices for agentic systems covering infrastructure, identity, lifecycle, and operational security
- Lists SIG leads: Jennings Aske (SailPoint), Kathleen Goeschel (Red Hat), Parul Singh (Red Hat)
- Describes the ADLC document deliverable: trust boundaries, controls, prerequisites, and residual risks across the agent lifecycle

## Test plan
- [x] Verify `SIGs/ADLC/README.md` renders correctly on GitHub
- [ ] Review by WS4 leads for alignment with repo reorganization