### PR TITLE
docs(agenda): add WS4 7/30 agenda draft

### DIFF
--- a/agenda_drafts/ws4/2026-07-30.md
+++ b/agenda_drafts/ws4/2026-07-30.md
@@ -1,0 +1,353 @@
+---
+schema_version: 1
+workstream: ws4
+meeting_date: 2026-07-30
+generated_at: 2026-07-30T00:50:00Z
+generated_by: imolloy
+generated_by_role: chair
+source_skill: cosai-ws4-meeting-agenda
+source_skill_version: 1.0.0
+status: draft
+promoted_to: null
+promoted_at: null
+supersedes: null
+---
+
+## Workstream 4 — Secure Design Patterns for Agentic Systems Agenda — July 30, 2026
+
+Last meeting: **2026-07-23** ([Discussion #147](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/147)).
+
+
+### Agenda
+
+| Time | § | Owner | Topic |
+|------|---|-------|-------|
+| 5'   | — | Ian Molloy ([@imolloy](https://github.com/imolloy)) | Action items |
+| 5'   | 1 | Ian Molloy ([@imolloy](https://github.com/imolloy)) | **V2 whitepaper — awaiting TSC call for consensus** *(mention)* |
+| 10'  | 2 | Imran Siddique ([@imran-siddique](https://github.com/imran-siddique)) / David Pierce | **Agent Manifest RFC** [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) *(new — Phase 1 review)* |
+| 5'   | 3 | Emrick Donadei ([@edonadei](https://github.com/edonadei)) / David Pierce | **MCP stateful-session** [#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) — V2 close-out |
+| 10'  | 4 | Nir Paz / David Pierce / Daniel Rohrer | ODIS migration — docs PR + ICLA |
+| 10'  | 5 | Benedict Lau / Rithikha Rajamohan | Agent Credentials — September draft target + `#99` |
+| 5'   | 6 | Parul Singh ([@husky-parul](https://github.com/husky-parul)) / Grant Miller | Identity Playbook — cluster YAML |
+| 5'   | 8 | Parul Singh / Chairs | ADLC SIG update (post-Jul 29) |
+| 10'  | 9 | Ian Molloy / Imran Siddique | GitHub agentic-spam mitigation — reputation-check algorithm |
+| 5'   | 11 | Leads | Cross-stream |
+
+### Reminders
+
+- **V2:** [PR #141](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/141) is ready for review; publication awaits the TSC call for consensus (§1).
+- **Agent Manifest Phase 1 window closes Aug 9** — named reviewers and the Agent Credentials boundary ask in §2.
+- **First-contributor screen:** [#146](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/146) and [#151](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/151) — triage detail in §10.
+- **GitHub-first still holds** except for the [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) credentials thread (Slack primary; issue stays open — Jul 16 decision unchanged).
+- **CoSAI-RM controls** — ~160 controls from WS4 papers still imminent; SME validation against NIST AI RMF / AI-1 outstanding.
+
+---
+
+### §1. V2 Whitepaper — Awaiting TSC Consensus (5') — Ian Molloy
+
+*`whitepaper` · [#106](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/106) · `v2 branch`*
+
+[PR #141](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/141) was marked ready for review Jul 30; the document has gone out to the TSC and **publication now waits on the TSC call for consensus**. Mention only — no discussion needed.
+
+Open point: PDF regeneration — Emrick/Ian/Sarah to trigger, or handled in-PR?
+
+---
+
+### §2. Agent Manifest RFC (10') — Imran Siddique / David Pierce *(new)*
+
+*RFC [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) `RFC` `review` · Phase 1 review through **Aug 9***
+
+Imran filed the RFC on Jul 27 per the Jul 23 decision to move Agent Manifest feedback onto GitHub. Framing: a single signed pre-execution record binding 10 deployment artifacts (system prompt, policy bundle, model identity, tool schemas, RAG corpus, memory baseline, decision trace, A2A delegation chain, build provenance, HITL approvals), hardware-anchored via SEV-SNP / TDX / TPM 2.0. Positioned as complementary to Agent Credentials [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) — Agent Manifest is the bound content a credential claim can attest against.
+
+**Jul 23 action item:** David Pierce + the group to critically review over 2–3 weeks; Imran committed to opening the Discussion — done.
+
+**Key questions for Jul 30:**
+
+1. Where does the boundary sit between [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) (pre-execution, content-bound) and [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) (identity- and access-bound at request time)? Kapil Singh raised the JWT-extension question Jul 23.
+2. TEE metadata schema addition — David's Jul 23 offer to contribute; landing in the RFC or a companion issue?
+3. Reviewers named in the RFC (Sarah, Ian, Ben, Rithikha, Kapil, Claudia) — commit to leaving structured feedback before Aug 9?
+4. Is the Azure MAA "deferred (offline-attestation limitation)" acceptable as a Phase 1 posture, or does it need to move up?
+
+| Owner | Action |
+|-------|--------|
+| David Pierce | File TEE-metadata schema proposal against [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) *(carried from Jul 23)* |
+| Sarah Novotny / Ian Molloy / Benedict Lau / Rithikha Rajamohan / Kapil Singh / Claudia Rauch | Leave structured Phase 1 feedback on [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) before Aug 9 |
+| Imran Siddique + [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) authors | Work out the manifest ↔ credential scope boundary; capture as an inline section in [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) |
+---
+
+### §3. MCP Stateful-Session — V2 Close-Out (5') — Emrick Donadei / David Pierce
+
+*[#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) — open, unlabeled*
+
+Emrick filed [#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) during the Jul 23 meeting, listing seven stateful-session gaps against the V2 threat model. The issue title currently says "blocking #141" — **chairs' position: not a V2 blocker**; publication proceeds via the TSC consensus call (§1). David's Jul 23 read: the current paper is adequate.
+
+**Key questions for Jul 30:**
+
+1. Confirm not-a-blocker status; retitle and re-scope [#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) accordingly.
+2. Which of the seven gaps route to V3 scope vs. playbook content?
+
+| Owner | Action |
+|-------|--------|
+| Emrick Donadei | Retitle [#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) (drop "blocking #141"); add labels + body cleanup |
+| Group | Review [#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) open questions; assign V3 vs. playbook routing *(carried from Jul 23)* |
+
+---
+
+### §4. ODIS Migration (10') — Nir Paz / David Pierce / Daniel Rohrer
+
+*[Discussion #134](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/134) (ODIS RFC)*
+
+Jul 23 update: ODIS technical code **merged** by David the morning of the meeting. Docs PR pending ICLA signature (Nir Paz). Reference implementation is being built at NVIDIA using OpenShell + APF; Nir presented to AIF (LF) with positive results. Claudia Rauch reported an OASIS cross-fora collaboration session being organized for late August to coordinate ODIS topics with other bodies.
+
+**Key questions for Jul 30:**
+
+1. Docs PR — ICLA cleared, ready to submit?
+2. Late-August cross-fora session — date + WS4 attendees confirmed?
+3. AAuth ↔ ODIS architecture mapping (Jul 16 group action) — findings?
+4. David Pierce Jul 16 action: state information for PQC addendum + ODIS docs — PQC portion presumably landed with #93; ODIS portion still?
+
+| Owner | Action |
+|-------|--------|
+| Nir Paz | Submit ODIS docs PR aligned to OASIS structure; complete ICLA |
+| Claudia Rauch (OASIS) | Confirm late-August cross-fora date; publish attendee ask |
+| Group | AAuth ↔ ODIS mapping — document findings *(carried from Jul 16)* |
+| David Pierce | Confirm state information landed in ODIS docs *(remainder from Jul 16 action)* |
+
+---
+
+### §5. Agent Credentials — September Draft Target (10') — Benedict Lau / Rithikha Rajamohan
+
+*RFC [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) `accepted` · CPEX↔OCSF [#94](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/94)*
+
+Jul 23 decisions: (a) **first draft target = September** accounting for summer scheduling; (b) definitions section complete → current Agent Credentials PR closed as sufficient for the draft. #99 remains open with Slack as primary venue for spam-affected discussion; latest substantive comment Jul 25 (@vaaraio) on three sub-properties under a single non-agent-assertable column.
+
+**Key questions for Jul 30:**
+
+1. September draft — outline confirmed? Section owners assigned?
+2. Scope-table walk-through (deferred from Jul 23) — ready this call?
+3. Manifest ↔ credential boundary (§2 above) — Ben / Rithikha input needed on [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149).
+4. AIAF credentials WG (Kapil Singh) — coordination cadence?
+
+| Owner | Action |
+|-------|--------|
+| Benedict Lau / Rithikha Rajamohan | Publish September draft outline + section owners |
+| Rithikha Rajamohan | Update [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) with Jul 9 notes; Miro map; team status *(carried)* |
+| Rithikha Rajamohan | Reclassify [#86](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/86) as sub-issue of [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) *(carried)* |
+
+---
+
+### §6. Identity Playbook — Cluster YAML (5') — Parul Singh / Grant Miller
+
+*`playbook` · [#52](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/52) / [#87](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/87) · Trust Graph [#50](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/50)*
+
+No visible movement since Jul 23. [PR #116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) last updated Jul 9. Parul's Jul 16 action to share pending YAML files still open.
+
+**Key questions for Jul 30:**
+
+1. YAML share — status?
+2. AIAF ↔ ODIS coordination (Grant / Nir) — offline outcome?
+
+| Owner | Action |
+|-------|--------|
+| Parul Singh | Share pending YAML files; recreate [PR #116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) with cluster YAMLs *(carried)* |
+| Grant Miller / Nir Paz | Coordinate AIAF ↔ ODIS synergies offline *(carried)* |
+
+---
+
+### §7. Multimodal Agentic Security (not on today's agenda) — Shriti Priya
+
+*`multimodal` · RFC [#113](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/113) `accepted` · [Discussion #150](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/150) (Jul 27 SIG agenda)*
+
+SIG met Jul 27. Focus areas: modality-independent taxonomy (Kevin Calloway), omnimodal/world-model approach (David Pierce), action-layer containment (Mayur + Imran, [cross-modality-action-layer-containment RFC](https://github.com/Mayur021/cross-modality-action-layer-containment)). Open question raised Jul 23 in the parent meeting: specification-only or specification + reference validator? Sarah's guidance: align to NIST / CSA rather than duplicate.
+
+**Upcoming questions** *(not on today's agenda — for report-back or a future slot)*:
+
+1. Spec-only vs. spec + reference validator — decision from Jul 27?
+2. Action-layer containment approach — WS4 adoption path?
+3. NIST deconfliction thread (Raymond Sheh Jul 23) — progressed?
+
+| Owner | Action |
+|-------|--------|
+| Shriti Priya ([@monshri](https://github.com/monshri)) | Report Jul 27 SIG outcomes; content PR against `main` *(carried)* |
+
+---
+
+### §8. ADLC SIG Update (5') — Parul Singh / Chairs
+
+ADLC SIG met Jul 29 (yesterday) — Parul to report. End-of-August risk-listing target still active per Jul 8. Phase 0 (baseline behavior + intended use) + decommissioning scope carried from Jul 8. Latest ADLC agenda Discussion in the repo is still [#142](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/142) (Jul 15).
+
+| Owner | Action |
+|-------|--------|
+| Parul Singh | Report Jul 29 ADLC session outcomes |
+
+*Carried ADLC actions (working sessions, accelerated sessions + decommissioning scope, Phase 0 PR, observability gap, differential privacy, end-of-life risks doc) are tracked once in Action Item Follow-ups below.*
+
+---
+
+### §9. GitHub Agentic-Spam Mitigation — Reputation-Check Algorithm (10') — Ian Molloy / Imran Siddique
+
+Jul 23 discussion: Sarah confirmed Bill Stout's zombie-agents doc is being addressed at TSC / governance level as part of new CoSAI policy. David + Imran discussed practical distinction between human and agent activity; Imran cited prior GitHub work on a **reputation-check algorithm** categorizing profile activity as high / medium / low to prioritize or ignore automated traffic — committed to sharing links in Slack. Imran also noted the AGT rollout was overwhelmed by volume; suggested slowing future processes down.
+
+**Key questions for Jul 30:**
+
+1. Reputation-check algorithm links — landed in Slack? Adoption path for WS4?
+2. First-contributor items from this week — apply the screen to [#146](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/146) and [#151](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/151); triage detail in §10.
+3. GitHub outreach (Ian + Imran, Jul 16) — first responses?
+
+| Owner | Action |
+|-------|--------|
+| Imran Siddique | Share reputation-check algorithm documentation in Slack *(Jul 23 action)* |
+| Ian Molloy | Start Slack thread on GitHub spam mitigation; collect examples *(carried from Jul 16)* |
+| Ian Molloy / Imran Siddique | Contact GitHub for OSS spam management recommendations *(carried from Jul 16)* |
+
+---
+
+### §10. PR Pickups + New Triage (10') — All
+
+**PRs needing review:**
+
+| PR | Author | Notes |
+|----|--------|-------|
+| [**#141**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/141) | Ian Molloy ([@imolloy](https://github.com/imolloy)) | MCP Security Whitepaper V2 — **ready for review** as of Jul 30, no reviews yet; publication awaits TSC consensus call (§1) |
+| [**#121**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/121) | Imran Siddique ([@imran-siddique](https://github.com/imran-siddique)) | AGT-backed ADLC controls (DV/AD/RT) — updated Jul 26; disposition? |
+| [**#117**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/117) | Parul Singh | ADLC Controls & Audit Checklist skeleton — updated Jul 15; superseded / plan to resubmit? |
+| [**#116**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) | Parul Singh | Identity Architecture Patterns [WIP] — Parul recreating with cluster YAML (see §6) |
+| [**#91**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/91) | Gheorghina ([@gheorghina](https://github.com/gheorghina)) | AI Gateways Design & Implementation (`playbook`) — what's missing before merge? |
+| [**#89**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/89) | Rags Srinivasan ([@ragsvasan](https://github.com/ragsvasan)) | MCP runtime conformance (T1–T12) — awaiting Alex Polyakov review |
+| [**#92**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/92) | Sarah Novotny | AI Usage Policy for `CONTRIBUTING.md` — **on hold** (OASIS/CoSAI guidance pending) |
+| [**#72**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/72) | David ([@rabbidave](https://github.com/rabbidave)) | CoSAI practical guide patterns — **iCLA-blocked**; updated Jul 29 |
+| [**#59**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/59) | Manoj Parmar ([@parmarmanojkumar](https://github.com/parmarmanojkumar)) | github.io docs pages — folds into new-repo/docs effort |
+
+**New issues since last meeting (Jul 23):**
+
+| Issue | Author | Notes |
+|-------|--------|-------|
+| [**#148**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) | Emrick Donadei ([@edonadei](https://github.com/edonadei)) | Stateful-session gaps vs. V2 threat model — **not a V2 blocker per chairs**; retitle + labels + body cleanup (see §3) |
+| [**#149**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) | Imran Siddique ([@imran-siddique](https://github.com/imran-siddique)) | **[RFC] Agent Manifest** — `RFC` + `review`; Phase 1 through Aug 9 (see §2) |
+| [**#151**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/151) | @kingztech2019 | Composite `policy_bundle` — no defined semantics for conflicting per-jurisdiction SLAs; filed against #149. **First-time contributor — screen before disposition (§9):** account dates to 2019 but public activity was near-dormant through 2025, then surged in 2026 (106 commits, 21 PRs, 23 new repos); cites production Rego policy packs |
+
+**RFC chair dispositions pending:**
+
+| Issue | Labels | Notes |
+|-------|--------|-------|
+| [**#146**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/146) — CBAE | `review` | Filed Jul 23 by first-time contributor; substantive Jul 23–24 review with @0xbrainkid; author revised body with min. evidence-record shape — **apply `accepted` or defer?** |
+| [**#94**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/94) — CPEX | `RFC` `review` | CPEX↔OCSF aligning with credentials work — **apply `accepted`?** *(carried)* |
+| [**#100**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/100) — ATR | `RFC` `review` | Companion issues [#139](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/139) and [#125](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/125); [Discussion #115](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/115) |
+| [**#130**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/130) — ADLC scoping matrix | `review` | Accept / route to ADLC SIG? *(carried)* |
+| [**#86**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/86) — Runtime governance | `RFC` `review` | Reclassify as sub-issue of [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99)? *(carried)* |
+| [**#61**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/61) — Per-Decision Accountability | `RFC` `review` | Latest activity Jul 28 (@yc-oia); disposition still needed *(carried)* |
+| [**#9**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/9) — Secured Agentic Execution | `review` | Long-standing; disposition needed *(carried)* |
+
+**Unlabeled — needs triage:**
+
+| Issue | Notes |
+|-------|-------|
+| [**#132**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/132) | ARA — Agent Runtime Assurance; still unlabeled, no substantive comments since Jul 1 |
+| [**#125**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/125) | MCP threat → detection crosswalk (Adam Lin) — suggest `playbook` + relate to #100 *(carried)* |
+| [**#110**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/110) | SVR signed receipts — AIPOU + SATP interop; contribution-path decision needed *(carried)* |
+| [**#64**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/64) / [**#63**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/63) | V2 Proposals: OWASP schema-first validation / minimum-bar parity — suggest `whitepaper` + `v2 branch` *(carried)* |
+| [**#11**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/11) / [**#7**](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/7) | Identity mgmt/TBAC; MCP handshake diagram — suggest label/triage *(carried)* |
+
+---
+
+### §11. Cross-Stream (5') — Leads
+
+| Topic | Status |
+|-------|--------|
+| **TSC** | PQC now on `main` after TSC-aligned rewrite; V2 whitepaper presentation to TSC is Ian's outstanding Jul 23 action — schedule? |
+| **ADLC SIG** | Met Jul 29 — report in §8 |
+| **Multimodal SIG** | Met Jul 27 ([Discussion #150](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/150)) — not on today's agenda; upcoming questions in §7 |
+| **AIAF** | Credentials WG (Kapil Singh); NVIDIA reference implementation using OpenShell + APF (Nir Paz, presented Jul 23 with positive AIF response) |
+| **OASIS cross-fora** | Late-August ODIS coordination session (Claudia Rauch, Jul 23) — date + attendees? |
+| **Org / docs** | CoSAI-org repo + README template + SIG graphic — David LaBianca + Claudia Rauch (no update) |
+| **IETF alignment** | Poorna Rajaraman still to post agentic findings → [Discussion #104](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/104) |
+| **NIST** | Raymond Sheh (Jul 23): NIST doing similar deconfliction; intends to reference this group's work |
+
+| Owner | Action |
+|-------|--------|
+| David LaBianca / Claudia Rauch | Create CoSAI-org repo + README template; publish workstream/SIG graphic *(carried)* |
+
+---
+
+### §12. Future-Meeting Topic — SLAs + Conformal Prediction — David Pierce *(requested Jul 23)*
+
+David Pierce requested a dedicated slot on SLAs and conformal prediction. Sarah asked David to share reference documentation in Slack ahead of the discussion so the group could prep. **Not on today's agenda — flagged for scheduling once materials are shared.**
+
+| Owner | Action |
+|-------|--------|
+| David Pierce | Share SLA + conformal-prediction reference materials in Slack; propose meeting slot |
+
+---
+
+### Action Item Follow-ups
+
+| Owner | Action | Status |
+|-------|--------|--------|
+| Ian Molloy | Merge PQC changes into V2 branch ([PR #93](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/93)) | **Done → PR #93** (merged 2026-07-30 00:38 UTC) |
+| Ian Molloy | Push Quantum PR with final corrections | **Done → PR #93** (Jul 30 commits: "PQC per TSC feedback", "addresses inability comment") |
+| Ian Molloy | Drive remaining V2 content scope before July 28 | [PR #141](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/141) marked ready for review Jul 30; awaiting TSC call for consensus (§1) |
+| Ian Molloy | Present MCP V2 whitepaper to TSC | New from 7/23 — not scheduled |
+| Nir Paz | Submit ODIS documentation PR (ICLA-aligned) | New from 7/23 |
+| Imran Siddique | Start GitHub Discussion for Agent Manifest | **Done → [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149)** (filed Jul 27) |
+| Emrick Donadei | Create GitHub issue to track V2 protocol open questions | **Done → [#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148)** (filed Jul 23) |
+| David Pierce / the group | Critical review of Agent Manifest artifacts over 2–3 weeks | New from 7/23 — in progress; Phase 1 window closes Aug 9 |
+| Emrick Donadei / the group | Review open questions in [#148](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/148) | New from 7/23 |
+| Imran Siddique | Share reputation-check algorithm links in Slack | New from 7/23 |
+| David Pierce | Share SLA + conformal-prediction reference material in Slack | New from 7/23 (see §12) |
+| David Pierce | Update PQC addendum + ODIS docs with state information | Partial — PQC portion landed with [PR #93](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/93); ODIS portion? *(from 7/16)* |
+| David Pierce | Document VLM + llama.cpp implementation examples; concurrent vs. agentic serving patterns | ? (carried from 7/16) |
+| Nir Paz | Investigate OpenShell integration — does it use ODIS identity layer? | Partial — NVIDIA reference implementation confirmed using OpenShell + APF (Jul 23) |
+| Nir Paz | Review IATF proposal (Kapil's link) for agent-identity alignment | ? (carried from 7/16) |
+| The group | Map AAuth standards to current ODIS architecture; document findings | ? (carried from 7/16) |
+| Parul Singh | Share pending YAML files for the collaboration work | ? (carried from 7/16) |
+| Claudia Rauch (OASIS) | Confirm late-August cross-fora session date + Mural availability | New from 7/23 (partial — session announced; date TBD) |
+| Benedict Lau / Rithikha Rajamohan | Publish September draft outline + section owners for Agent Credentials | New from 7/23 |
+| Ian Molloy | Start Slack thread on GitHub spam mitigation; collect examples | ? (carried from 7/16) |
+| Ian Molloy / Imran Siddique | Contact GitHub for spam-management recommendations | ? (carried from 7/16) |
+| Rithikha Rajamohan | Update RFC [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) with Jul 9 meeting notes | ? (carried from 7/9) |
+| Rithikha Rajamohan | Map credentialing work on Miro board | ? (carried from 7/9) |
+| Rithikha Rajamohan | Get status from Ben Lau and team on credentialing | ? (carried from 7/9) — see §5 |
+| Rithikha Rajamohan | Reclassify [#86](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/86) as sub-issue of [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) | ? (carried) |
+| Grant Miller / Nir Paz | Coordinate AIAF ↔ ODIS synergies offline | ? (carried from 7/9) |
+| Sarah Novotny / Ian Molloy / Grant Miller | ODIS ↔ Agentic AI Foundation (LF Identity & Trust WG) partnership | ? (carried) |
+| Parul Singh / Ian Molloy | Clarify scope/intent of [PR #116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) now that it is reopened | ? (carried) |
+| John Cavanaugh | Validate ~160 CoSAI-RM controls; align with NIST AI RMF + AI-1 | ? (carried) |
+| Sarah Novotny / David LaBianca | Decide controls bundling approach; confirm SME list | ? (carried) |
+| Shriti Priya | Finalize meeting-time vote; file content PR | ? (carried) |
+| Emrick Donadei | Write benchmarking position statement | ? (carried) |
+| Donald Hunter | Sync with Emrick; report first steps + internal-research findings | ? (carried) |
+| Alex Polyakov | Review Rags' MCP scanner ([PR #89](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/89)) | ? (carried) |
+| Doyin Awofodu / David Pierce / Parul Singh | Schedule missed risk-definition session (David demo) | ? (carried) |
+| David LaBianca / Claudia Rauch | Create CoSAI-org repo + README template; publish SIG graphic | ? (carried) |
+| Parul Singh | Schedule ADLC working sessions for risk-listing brainstorming | ? (carried from 7/8) |
+| Parul Singh | Schedule 2-hour accelerated sessions; resolve decommissioning scope | ? (carried from 7/8) |
+| Parul Singh | Create Phase 0 PR — ADLC baseline behavior + intended use | ? (carried from 7/8) |
+| Parul Singh / David LaBianca | Schedule observability-gap discussion | ? (carried from 7/8) |
+| David Pierce / David LaBianca / Ian Molloy | Schedule differential-privacy + private-inference discussion | ? (carried from 7/8) |
+| Raymond Sheh | Clean up and share end-of-life risks document | ? (carried from 7/8) |
+| Raghuram Yeluri / David Pierce / Emrick Donadei | Schedule stateful-MCP working meeting; V2 vs V3 scope decision | **Done — David Jul 23: current paper adequate; #148 close-out pending (§3)** |
+| David Pierce | Develop open version of stateful-agents framework | ? (carried from 7/9) |
+| Donald Hunter | Loop Arthur Kavanagh + John Cavanaugh into revised PQC scope | Done — engagement completed on [PR #93](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/93); PR merged |
+
+---
+
+### Carried Actions (not on today's agenda)
+
+| Owner | Action | Carried since |
+|-------|--------|--------------|
+| Sarah Novotny | Project-page mission statement (research/POC focus) | 5/14 |
+| Bill Stout | Machine-readable (YAML) renderings of WS4 outputs | — |
+| Bill Stout | Zombie-agents doc — now being handled at TSC/governance level per Jul 23 | — |
+| Poorna Rajaraman | Post IETF agentic findings → [Discussion #104](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/104) | — |
+
+---
+
+### Reference Materials
+
+- [Discussion #147](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/147) — WS4 July 23 agenda (prior)
+- [Discussion #150](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/150) — Multimodal Agentic Security agenda (Jul 27)
+- [Discussion #142](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/142) — ADLC SIG July 15 agenda
+- [Discussion #134](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/134) — ODIS RFC Discussion
+- [Discussion #115](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/115) — ATR (Agent Threat Rules) intro
+- [Discussion #104](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/104) — IETF agentic findings
+- [Discussion #84](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/84) — Agenda format reference


### PR DESCRIPTION
Adds the WS4 2026-07-30 meeting agenda draft (`agenda_drafts/ws4/2026-07-30.md`).

The draft was generated by @imolloy with the `cosai-ws4-meeting-agenda` skill, then chair-reviewed and corrected against live repo state before commit:

- V2 whitepaper reframed to a brief mention — PR #141 is ready for review; publication awaits the TSC call for consensus
- Missing §3 (MCP stateful-session close-out, #148) written, recording the chairs' position that #148 is not a V2 blocker
- Proper-noun normalization from the meeting transcripts (ODIS, AAuth, contributor names)
- First-contributor screen notes for #146 / #151 updated with account-history detail
- Repetition trimmed to one home per fact; timing rebalanced

## AI assistance disclosure

Per the WS4 contribution guidelines: Claude Code (Anthropic) was used to verify GitHub state (PR/issue status, labels, contributor history) and to apply the chair-directed review edits to the generated draft. Content decisions were made by the workstream chairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)