### PR TITLE
docs(agenda): add WS4 agenda draft for 2026-08-27

### DIFF
--- a/agenda_drafts/ws4/2026-08-27.md
+++ b/agenda_drafts/ws4/2026-08-27.md
@@ -1,0 +1,262 @@
+---
+schema_version: 1
+workstream: ws4
+meeting_date: 2026-08-27
+generated_at: 2026-08-26T19:13:22Z
+generated_by: sarahnovotny
+generated_by_role: chair
+source_skill: cosai-ws4-meeting-agenda
+source_skill_version: 1.0.0
+status: draft
+promoted_to: null
+promoted_at: null
+supersedes: null
+---
+
+## Workstream 4 — Secure Design Patterns for Agentic Systems Agenda — August 27, 2026
+
+Last meeting: **2026-08-20** ([Discussion #171](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/171)).
+
+> **Chairing:** Ian is out for two weeks (through the Sep 3 call). Sarah chairs; Ragu backup unconfirmed.
+> **Closed since we last met:** the sandboxing and isolation blog — [PR #167](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/167), merged Aug 25 (`d22430f`), reported to the TSC the same day.
+
+### Administrative — Deadlines and Polls
+
+| Item | Notes |
+|---|---|
+| **Deadlines** | - ADLC risk-listing for the decommissioning window — **end of August (Mon Aug 31)** |
+| **Polls** | - **TSC co-chair election — ballot closes EOB Friday, Aug 28**, the day after this call <br> - WS1 and WS2 paper approval ballots — TSC voting members, open this week |
+
+---
+
+### Agenda
+
+| Time | § | Owner | Topic |
+|------|---|-------|-------|
+| 5'   | — | Chairs | Action items |
+| 8'   | 1 | Emrick Donadei ([@edonadei](https://github.com/edonadei)) / Chairs | **ADLC direction — the SIG is asking the chairs for P0 priorities** |
+| 6'   | 2 | Emrick Donadei | **RFC [#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175) Observability — one blocking question** |
+| 6'   | 3 | Bill Stout ([@billbrietstout](https://github.com/billbrietstout)) | **RFC [#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) Decommissioning — rescoped to hard-only** |
+| 6'   | 4 | Sarah Novotny | **Containment follow-on paper ([#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172)) — reviewers named, sections claimed** |
+| 4'   | 5 | Sarah Novotny | [Telemetry working document](https://github.com/cosai-oasis/ws2-defenders/blob/main/telemetry/CoSAI-AI-Telemetry-RFC-0.3.md) — TSC requests WS4 review |
+| 4'   | 6 | Sarah Novotny | **Cross-stream — TSC Aug 25; co-chair transition and the Sep 1 standup** |
+| 3'   | 7 | Imran Siddique ([@imran-siddique](https://github.com/imran-siddique)) | Agent Manifest [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) — integration diagram |
+| 3'   | 8 | Chairs | Close-outs — contributor screening, and who documents [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) |
+
+**Total: 45'.** §9 (written updates — Multimodal, ODIS, repo hygiene) takes no time on the call.
+
+---
+
+### §1. ADLC Direction — the SIG Is Asking the Chairs for P0 Priorities (8') — Emrick Donadei / Chairs
+
+*From the ADLC SIG meeting earlier today (Aug 26). This is an escalation to the chairs, not a status update.*
+
+Three things surfaced in that session that only the chairs can settle:
+
+- **No foundational documents.** David questioned the current process, citing the absence of core papers defining what the ADLC is for and what it is meant to produce. The SIG is drafting risks and controls against a lifecycle no document defines.
+- **Priorities may be misaligned.** The group noted that current ADLC effort "may not reflect strategic focuses like sandboxing" — that is, the SIG may be working off-axis from where WS4 has actually committed.
+- **Cross-repository RFC filing is confusing.** Contributors do not know which repo an RFC belongs in, and links between them break. This is the same friction as the Phase 1 routing problem on [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149).
+
+Emrick has an action to consult the leads directly; this slot is that consultation, held in the open.
+
+**Questions to answer on the call:**
+
+1. What are WS4's P0 priorities for the rest of 2026, stated plainly enough that a SIG can self-check against them?
+2. Does the ADLC need a scope/goals document before more risk-listing, and who writes it?
+3. Where does an ADLC RFC get filed — here, or `secure-ai-tooling`? Can we write that down once?
+4. ADLC still needs a volunteer to lead two meetings a month (carried from Aug 13, still unfilled).
+
+---
+
+### §2. RFC #175 — Observability as a Risk Map Component (6') — Emrick Donadei
+
+*[#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175) `review`, filed Aug 26, unassigned. Authors: Parul Singh (originating), Emrick Donadei (RFC transcription).*
+
+Emrick asked for time at WS4 and has an ADLC action to present here; this is that slot.
+
+The implementation is already written: [`secure-ai-tooling#501`](https://github.com/cosai-oasis/secure-ai-tooling/pull/501) adds Observability with semantic and behavioral sub-components, is open, and passes every corpus check. It is blocked on exactly one decision:
+
+> **Is Observability a top-level category, or a subcategory under Application?**
+
+Answer that and the PR unblocks. The RFC estimates roughly an hour for the corpus change, and a follow-on catalog of 8 risks at roughly a day.
+
+**Questions:**
+
+1. Top-level or under Application — can we decide this on the call?
+2. @husky-parul is the originating author but has not reviewed the RFC text. Does she need to sign off before we act?
+3. Three further open questions in the RFC body — do they block, or can they land as follow-ups?
+
+---
+
+### §3. RFC #170 — Decommissioning, Rescoped to Hard-Only (6') — Bill Stout
+
+*[#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) `review`, filed Aug 19, assigned to @sarahnovotny and @imolloy, 5 comments.*
+
+The objection raised on Aug 20 has been resolved by narrowing the proposal. @NicolaiNielsenTR argued that "decommissioning" reads as terminal and non-revocable, so a soft mode that retains tokens and can restart misuses the word. @imran-siddique agreed and argued pause/quarantine should sit outside decommissioning entirely.
+
+**Today's ADLC session accepted that**: scope is now **hard decommissioning only**, and Bill has an action to strip the soft-decommissioning references from the RFC. The session also noted that hard decommissioning may still require data sealing or archival to satisfy forensic, regulatory, and record-keeping obligations — deletion is not the whole of it.
+
+@raymondsheh has committed to reviewing against his own notes ([shared doc](https://docs.google.com/document/d/1zOnvzIV_c_S-7IQ3caucBRUgcB9sZBINJBvKdSZx_mQ/edit)).
+
+**Questions:**
+
+1. With soft mode removed, is the RFC ready for a chair decision, or does it need another SIG pass?
+2. The `lifecycle-stage.yaml` change (order 9) lands in `secure-ai-tooling` — does that need its own PR now, or wait on the RFC?
+3. ADLC risk-listing deadline is **end of August — this Monday.** Does decommissioning drafting proceed with a provisional tag, or slip?
+
+---
+
+### §4. Containment Follow-on Paper — Reviewers Named, Sections Claimed (6') — Sarah Novotny
+
+*[#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172), filed Aug 24, 4 comments, **still unlabeled and unassigned**.*
+
+The blog merged Aug 25. The follow-on paper — the deeper material deliberately deferred out of the blog — now has both reviewers and volunteer authors, which it did not have a week ago.
+
+**From the TSC (Aug 25):** Sarah called for reviewers on the longer paper; **Akila Srinivasan, David LaBianca, and Jodi Middleton (NVIDIA) volunteered.**
+
+**From the thread, since Aug 25:**
+
+| Who | Commitment |
+|-----|-----------|
+| @skvcool-rgb | Taking **Q7** — aggregate accounting over a delegation subtree, evaluated at the consuming action |
+| @Levaj2000 | **Delivered** the Q14/Q15 contract-to-OCSF mapping, pinned to OCSF v1.9.0, with four upstream gaps filed against `ocsf/ocsf-schema` |
+| @imran-siddique | Argues detection and evidence belong in the core containment model, with OCSF detail in the playbook |
+
+Josiah's telemetry work at the TSC is pointed at the same OCSF surface (see §5) — worth not duplicating.
+
+**Questions:**
+
+1. Label and assign [#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172) — it is carrying real commitments while formally untriaged.
+2. Is detection/evidence in the core paper or the playbook? @imran-siddique and @Levaj2000 have framed this as two artifacts, not one.
+3. Outline and section owners — who holds the pen, and what is the target date?
+
+---
+
+### §5. Telemetry Working Document — TSC Ask on WS4 (4') — Sarah Novotny
+
+*TSC action item, Aug 25: "Present the telemetry documentation to workstream 4 for review and feedback."*
+
+Josiah presented the telemetry document to the TSC as a working map for aligning changes with **OCSF and OpenTelemetry**, and reported the telemetry group added three risks and a control after its MCP review. He asked for review from members working on ODIS or adjacent telemetry standards, to get reference attacks into the CoSAI risk map.
+
+**Questions:** who from WS4 reviews it?
+
+---
+
+### §6. Cross-Stream — TSC August 25 (4') — Sarah Novotny
+
+| Item | What it means for WS4 |
+|------|----------------------|
+| **Co-chair transition** | Akila and JR finish as TSC co-chairs at the end of this month |
+| **Workstream standup, Sep 1 TSC** | Akila is running a review of every workstream — progress, accomplishments, blockers. WS4 needs a position prepared, and Ian is away |
+| **Scope and roadmap realignment** | Claudia proposed revisiting scope/goals/roadmaps across all workstreams; scheduled for **Sep 8** |
+| **Open ballots** | Co-chair ballot, plus WS1 and WS2 paper approval — TSC voting members, this week |
+| **Zero Trust paper** | Josiah confirmed sandboxing/isolation is distinct from the zero trust paper and is WS4's to carry; a link to the containment blog can be added |
+| **Effectiveness metrics** | OASIS gauges via contributor growth, stars, and Karttik's citation list. Bill asked how workstreams are measured — relevant to the Sep 8 conversation |
+
+**Question:** what does WS4 put in front of the TSC on Sep 1, and who presents it if Ian is still out?
+
+#### A WS4 deliverables view — to be developed with the SIGs and subgroups
+
+The TSC maintains a central deliverables roadmap with a stage and a next deadline for
+every item, and it drives the Sep 1 standup and the Sep 8 scope conversation. WS4 has no
+equivalent view of its own, so what the workstream has committed to lives scattered across
+issues, SIG working docs, and meeting minutes — and no SIG or subgroup can see the whole.
+
+Building one is a joint exercise, not a chair deliverable: **ADLC SIG, Multimodal Agentic
+Security, Agent Credentials, and ODIS each own entries in it.** The table below is a
+straw-man for that conversation, drafted from what is currently visible — treat it as
+pre-read, and correct your own rows.
+
+| Deliverable | Group / owner | Stage | Next milestone |
+|---|---|---|---|
+| Agentic isolation blog | Chairs | Merged Aug 25 | Website publication and promotion |
+| Containment follow-on paper | [#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172) — chairs + volunteer authors | Scoping; reviewers named | Outline and section owners |
+| ADLC risks and controls | ADLC SIG | Risk-listing in progress | End of August |
+| Decommissioning as lifecycle stage 9 | [#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) — Bill Stout | RFC, rescoped to hard-only | Chair decision |
+| Observability component | [#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175) — Parul Singh, Emrick Donadei | RFC filed; implementation ready | One blocking question (§2) |
+| Multimodal threat taxonomy | Multimodal Agentic Security group | Scope agreed Aug 24 | Taxonomy draft |
+| Agent credentials paper | Agent Credentials group | Drafting by section | Late September |
+| Agent Manifest | [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) — Imran Siddique | RFC under review | Integration diagram |
+| MCP security whitepaper V2.x residuals | [#163](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/163) — chairs | Editorial follow-ups open | Scope and schedule |
+
+**Asks:** who owns building and maintaining this view, where does it live, and do we mirror
+it into the TSC roadmap so WS4 is represented accurately at the Sep 1 standup?
+
+---
+
+### §7. Agent Manifest — Integration Diagram (3') — Imran Siddique
+
+*[#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) `review` `RFC`, 22 comments, last updated Aug 24.*
+
+Two actions from Aug 20, both open: update the RFC to explain how the Agent Manifest integrates with Agent Card and adjacent standards, and produce a diagram showing how the standards relate and where they integrate. The Aug 20 discussion landed on treating the manifest as an **integration point, not a replacement** (Nicolai), and assigned schema unification between Manifest and Agent Credentials to the Agent Credential group.
+
+The Aug 9 Phase 1 disposition summary remains unposted — **18 days overdue**.
+
+**Questions:** when does the diagram land, and does the Phase 1 summary still matter now that the thread has moved past it?
+
+---
+
+### §8. Close-Outs (3') — Chairs
+
+**Contributor screening — decided, record not closed.** The Aug 20 call decided against running the automation in CoSAI repositories. @imran-siddique closed [PR #157](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/157) himself that evening and rewrote [#156](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/156) to propose it as a reference runbook rather than an operated control. **[#156](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/156) is still open, unlabeled and unassigned, 26 days on.** Also unresolved: [Discussion #129](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/129) is still accumulating comments (21, last Aug 23) and was never dispositioned.
+
+- Accept as a documented pattern, or decline outright?
+- Either way, label it and close the thread.
+
+**Documenting [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99).** Closed Aug 13 by @benhylau after 102 comments. The Aug 20 action to "summarize the useful information and relocate it to a permanent document" is assigned to *the group*, which means nobody. Needs a name and a destination.
+
+---
+
+### §9. Written Updates — No Time Allocated
+
+| Topic | Status |
+|-------|--------|
+| **Multimodal Agentic Security** | Met Aug 24 ([Discussion #173](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/173)). Scope is **threat taxonomy, not mitigations**. Shriti presented a 5-part categorization; Victor recommended prioritizing MITRE ATLAS, with OWASP for emerging scenarios, and flagged the EU Act Code of Practice as behind. Open debate on whether crossmodal composition is a distinct threat class |
+| **ODIS event** | **Date conflict — confirm on the call.** Aug 13 minutes say Aug 27 at NVIDIA; Aug 20 minutes say "next Friday" (Aug 28). Over capacity from walk-ins. @nirpaz owes a remote link and a README PR |
+| **Blog publication** | Merged Aug 25. Claudia scheduled CoSAI website publication for Aug 25 — **confirm it is live**. Promotion with Mary Beth and Ian's social copy both outstanding, and Ian is away |
+| **Stale PRs** | [#116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) identity playbook (Jun 10) · [#92](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/92) AI usage policy (May 5) · [#89](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/89) MCP conformance guide (Apr 28) · [#72](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/72) practical guide patterns (Apr 7) |
+| **Minutes tooling** | `scripts/fetch_meeting_minutes.py` now covers the Multimodal group, WS1, WS2 and PGB, and recovers notes filed loose in Drive parent folders — which had been silently costing recent ADLC and Code-SIG minutes |
+
+---
+
+### Action Item Follow-ups
+
+| Owner | Action | Status |
+|-------|--------|--------|
+| Sarah Novotny | Merge the isolation blog | ✅ **Done** → [PR #167](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/167), merged Aug 25 (`d22430f`) |
+| Ian Molloy, Sarah Novotny | Ping David for detection/noisiness language | ✅ **Done** — Sarah reported to the TSC Aug 25 that David L's feedback was incorporated |
+| Ian Molloy | Integrate blog feedback (from Aug 13) | ✅ **Done** → merged in [#167](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/167) |
+| Parul Singh | Email David re: observability component (from Aug 13) | ✅ **Done** → became RFC [#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175) |
+| Claudia Rauch (OASIS) | Publish blog to the CoSAI website | ❓ Scheduled for Aug 25 per TSC — confirm live |
+| Claudia Rauch (OASIS) | Coordinate promotion with Mary Beth | ❓ Unknown |
+| Ian Molloy | Draft 1–2 sentences of social copy | ✅ **Done** |
+| Bill Stout | Refine the decommissioning proposal | 🔄 **In progress** — ADLC narrowed scope to hard-only Aug 26; RFC edit outstanding |
+| Raymond Sheh | Review decommissioning RFC against his notes | 🔄 In progress — committed Aug 26 |
+| Emrick Donadei | Present the observability RFC to WS4 | 🔄 **On today's agenda** (§2) |
+| Emrick Donadei | Consult the leads on ADLC process and priorities | 🔄 **On today's agenda** (§1) |
+| Emrick Donadei | Fix broken cross-repo links in the PR | ❓ New — raised Aug 26 |
+| Imran Siddique | Update RFC re: Agent Card integration | ⚠️ Carried Over — 1 meeting (since Aug 20) |
+| Imran Siddique | Draft the standards-integration diagram | ⚠️ Carried Over — 1 meeting (since Aug 20) |
+| Imran Siddique | Post the Phase 1 disposition summary | ⚠️ Carried Over — 3 meetings (since Aug 9); 18 days overdue |
+| Agent Credential group | Unify Manifest and Credential schemas | ⚠️ Carried Over — 1 meeting (since Aug 20) |
+| The group | Summarize [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) into a permanent document | ⚠️ Carried Over — 1 meeting (since Aug 20); **unowned**, needs a name (§8) |
+| The group | Volunteer to lead two ADLC meetings a month | ⚠️ Carried Over — 2 meetings (since Aug 13); still unfilled |
+| Nir Paz | Share the ODIS remote link | ⚠️ Carried Over — 1 meeting (since Aug 20) |
+| Nir Paz | ODIS README PR | ⚠️ Carried Over — 2 meetings (since Aug 13) |
+| Daniel Major | Review the agent manifest proposal | ⚠️ Carried Over — 2 meetings (since Aug 13) |
+| Sarah Novotny | Present telemetry documentation to WS4 | 🔄 **On today's agenda** (§5) — new TSC action, Aug 25 |
+
+**Status Key:** ✅ Done · 🔄 In Progress · ⚠️ Carried Over · ❓ Unknown
+
+Done items stay on this agenda for visibility and drop off next week.
+
+---
+
+### Reference Materials
+
+- [Discussion #171](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/171) — WS4 agenda, Aug 20
+- [Discussion #174](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/174) — ADLC SIG agenda, Aug 26
+- [Discussion #173](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/173) — Multimodal Agentic Security, Aug 24
+- TSC minutes, Aug 25 — co-chair transition, workstream standup, telemetry, isolation follow-on reviewers
+- [`secure-ai-tooling#501`](https://github.com/cosai-oasis/secure-ai-tooling/pull/501) — Observability component implementation, blocked on §2
+- [`practical-guides/mcp-runtime-isolation.md`](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/blob/main/practical-guides/mcp-runtime-isolation.md) — existing isolation cookbook


### PR DESCRIPTION
Chairs' agenda draft for the August 27 call, matching the format used for the Aug 13 and Aug 20 agendas.

Ian is away for two weeks, so this covers the Aug 27 and Sep 3 meetings being chaired solo.

**Sources:** Aug 13 and Aug 20 WS4 minutes, the Aug 26 ADLC SIG session, the Aug 25 TSC minutes, and open issues and pull requests.

**Three conventions adopted from the [TSC meeting-agenda skill](https://github.com/cosai-oasis/cosai-tsc/blob/main/skills/cosai-tsc-meeting-agenda.md):**

- A standing **Deadlines and Polls** block — surfacing that the TSC co-chair ballot closes EOB Friday Aug 28, the day after this call.
- The shared **status vocabulary** for action items (✅ / 🔄 / ⚠️ / ❓) with carry counts.
- A **deliverables view**. Unlike the TSC's, this one is explicitly a straw-man for the SIGs and subgroups to build out together — ADLC SIG, Multimodal Agentic Security, Agent Credentials and ODIS each own rows in it. It is not a chair-maintained artifact.

Per-item time estimates are kept, diverging from the TSC skill, which bans them. WS4 agendas have carried a Time column consistently and a 45-minute working call benefits from it.

---

**AI assistance disclosure.** Drafted with AI assistance (Claude Code) from the sources listed above, then reviewed and edited by the chair before filing. The assistant gathered and summarised minutes, issues and pull requests, and produced the initial structure; content decisions, the time budget and all framing are the chair's.