### PR TITLE
docs(agenda): add WS4 agenda draft for 2026-09-03 and Sep 1 TSC report

### DIFF
--- a/agenda_drafts/ws4/2026-09-01-tsc-report.md
+++ b/agenda_drafts/ws4/2026-09-01-tsc-report.md
@@ -1,0 +1,142 @@
+---
+title: "WS4 — State of the Workstream: deliverables and target timelines"
+audience: CoSAI TSC
+meeting: 2026-09-01 TSC (1:00–2:00 PM ET), agenda item 8
+presenter: Sarah Novotny (Ian Molloy away)
+source: WS4 minutes 2026-08-27; TSC minutes 2026-08-25; repo issue/PR state as of 2026-09-01
+---
+
+# WS4 — State of the Workstream
+
+**Why this exists:** the 2026-08-25 TSC scheduled a workstream standup for today, and
+the 2026-08-27 WS4 call took an action on the group to "outline upcoming project
+deliverables and target timelines to present at the September 1 meeting."
+
+**The headline:** the TSC deliverables roadmap carries **one** WS4 row — the agentic
+isolation blog, marked complete. WS4 shipped a second major deliverable that never
+appeared on the roadmap at all, and has seven more in flight. §4 supplies the rows.
+
+---
+
+## 1. Shipped
+
+| Deliverable | Evidence | On TSC roadmap? |
+|---|---|---|
+| **MCP Security Whitepaper V2** | PR [#141](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/141) merged 2026-08-12; publication and social distribution reported to WS4 on 2026-08-27 | ❌ **No — never listed** |
+| **Agentic Isolation blog** — *"Treat Your Agent Like an Insider Threat: Why AI Sandboxing Can't Wait"* | PR [#167](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/167) merged 2026-08-25; **verified live** on coalitionforsecureai.org, dated 2026-08-25 | ✅ Row 6, 🟢 Complete |
+
+> Correction for the record: the 2026-08-27 WS4 minutes say the blog is "awaiting
+> marketing committee posting." That was already stale when recorded — the post went
+> live on the CoSAI site on Aug 25. No marketing action is outstanding on publication;
+> promotion copy is.
+
+---
+
+## 2. In flight — seven deliverables
+
+Ordered by how close each is to landing.
+
+| # | Deliverable | Owner | Stage | Target | Who owes the date |
+|---|---|---|---|---|---|
+| 1 | **Observability as a CoSAI-RM component** ([#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175)) | Parul Singh, Emrick Donadei | RFC filed; implementation PR [secure-ai-tooling#501](https://github.com/cosai-oasis/secure-ai-tooling/pull/501) **written and validating green** | **~1 hour** after one decision; +1 day for the 8-risk catalog | Blocked on TSC/chairs — see §3 |
+| 2 | **ADLC risks and controls** | ADLC SIG | 30–40 risks identified | End of August — **now passed** | ADLC SIG; leadership gap is the cause (§3) |
+| 3 | **Agent Credentials paper** | Rithikha Rajamohan, Ben | Drafting by section; definitions consensus reached 2026-08-27 | **Late September 2026** — first draft | ✅ Owner-confirmed 2026-08-27 |
+| 4 | **Multimodal threat taxonomy** | Multimodal Agentic Security group (Shriti Priya, Raymond Sheh, Kevin) | Scope agreed 2026-08-24: **taxonomy, not mitigations**; 7-layer agentic stack mapped | Scope finalisation targeted for w/c 2026-08-24; draft date TBD | Group to set at next weekly |
+| 5 | **ADLC lifecycle definitional ("anchor") paper** | Emrick Donadei | Drafting; **set as the ADLC SIG's P0 on 2026-08-27**, ahead of containment | **TBD** | Emrick Donadei holds an open action to set it |
+| 6 | **Containment follow-on paper** ([#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172)) | Chairs + volunteer authors. TSC reviewers named 2026-08-25: **Akila Srinivasan, David LaBianca, Jodi Middleton** | Scoping — 21 scope questions banked from the blog review | **TBD** — next milestone is an outline with named section owners | Chairs, once placement resolves (§3) |
+| 7 | **MCP Security V2.x residuals** ([#163](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/163)) | Chairs | Two items: one editorial, one needing a chair decision on citing a pre-release OWASP document normatively | **TBD** | Chairs |
+
+**Two RFCs under review that are not yet deliverables** — they become deliverables if accepted:
+
+- [#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) **Decommissioning as ADLC phase / lifecycle stage 9** (Bill Stout). Rescoped to hard decommissioning only. David LaBianca objects to adding a phase before ADLC publishes foundational docs — unresolved, needs a chair call.
+- [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) **Agent Manifest** (Imran Siddique), Phase 2. Next: integration diagram, and reconciling the verifier/trace architecture with Raghuram Yeluri. May fold into Agent Credentials (#3 above).
+
+---
+
+## 3. What WS4 needs from the TSC — four asks
+
+1. **Unblock Observability (RFC #175, question 1).** Is Observability a **top-level
+   CoSAI-RM category** or a **subcategory under Application**? The implementation branch
+   is written and passes every corpus check; it waits only on this. Roughly fifteen
+   observability risks currently have no correct home, and ADLC risk drafting for the
+   Runtime and Reflection phases is blocked behind it. This is the same live blocker
+   as **today's agenda item 3** (#50, CoSAI-RM component rework).
+
+2. **ADLC SIG leadership.** Two leads stepped back for work reasons. The SIG paused RFC
+   work pending a check-in with the WS4 chairs. This is the direct cause of the missed
+   end-of-August risks deadline. *(Today's agenda item 9.)*
+
+3. **Where does the containment follow-on live?** The ADLC SIG is a **process** working
+   group; a technical how-to containment paper is an **implementation** artifact.
+   Raghuram Yeluri and I both flagged the mismatch on 2026-08-27. WS4's position: ADLC
+   focuses on the definitional lifecycle paper, and a broader workstream owns the
+   containment follow-on plus its technical playbooks. Confirming that placement lets
+   the named reviewers start.
+
+4. **Agent Credentials ↔ WS1 consolidation.** Kapil and Nicolai Nielsen proposed merging
+   parallel verifiable-claims threads to avoid fragmented, piecemeal output; WS1 is
+   separately exploring transportable evidence for AI/ML artifacts. This needs
+   TSC/OASIS guidance on how to unify rather than a WS4 decision. *(Today's agenda item 10.)*
+
+**Plus one housekeeping ask:** add the rows in §4 so WS4's forward work is visible on the
+roadmap ahead of the 2026-09-08 scope and realignment discussion.
+
+---
+
+## 4. Rows for `TSC Deliverables/roadmap.md`
+
+Copy-paste ready. Continues the Active Deliverables numbering from row 6.
+
+### Active Deliverables
+
+| # | Deliverable | Workstream / SIG | Current Stage | Next Deadline | Next Milestone |
+|---|---|---|---|---|---|
+| 7 | MCP Security Whitepaper V2 | WS4 — Secure Design Patterns for Agentic Systems | 🟢 Published / Complete | 2026-08-12 | Published; V2.x residuals tracked in #163 |
+| 8 | Agent Credentials Paper | WS4 — Agent Credentials Group | 🔵 In Progress | 2026-09-30 | First full draft |
+| 9 | ADLC Lifecycle Definitional Paper | WS4 — SIG ADLC | 🔵 In Progress | TBD | Emrick Donadei to set timeline |
+| 10 | Containment Follow-on Paper | WS4 — Secure Design Patterns for Agentic Systems | 🔵 In Progress | TBD | Outline with named section owners |
+| 11 | Multimodal Threat Taxonomy | WS4 — Multimodal Agentic Security Group | 🔵 In Progress | TBD | Taxonomy draft; scope agreed 2026-08-24 |
+| 12 | Observability CoSAI-RM Component | WS4 — SIG ADLC | 🔵 In Progress | Blocked | Category-vs-subcategory decision (#175 Q1) |
+| 13 | ADLC Risks and Controls | WS4 — SIG ADLC | 🔵 In Progress | Overdue (end of Aug) | 30–40 risks identified; blocked on #175 and SIG leadership |
+
+### Papers & Points of View
+
+| Title | Workstream / SIG | Owner | Start Date | Target Date | Status | Issue |
+|---|---|---|---|---|---|---|
+| MCP Security Whitepaper V2 | WS4 | Sarah Novotny, Ian Molloy | | 2026-08-12 | 🟢 Published / Complete | [#141](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/141) |
+| Agent Credentials Paper | WS4 | Rithikha Rajamohan | | 2026-09-30 | 🔵 In Progress | |
+| ADLC Lifecycle Definitional Paper | WS4 / SIG ADLC | Emrick Donadei | | TBD | 🔵 In Progress | |
+| Containment Follow-on Paper | WS4 | Sarah Novotny, Ian Molloy | 2026-08-25 | TBD | 🔵 In Progress | [#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172) |
+| Multimodal Threat Taxonomy | WS4 / Multimodal Agentic Security | Shriti Priya | | TBD | 🔵 In Progress | [#113](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/113) |
+
+### Blog Posts
+
+Row 1 is already present and correct; verified live on the CoSAI site 2026-08-25.
+
+---
+
+## 5. Three-minute talk track
+
+WS4 is item 8 of 10 in a 40-minute block. If time collapses, say items 1–3 and point at
+this document.
+
+1. **We shipped two things since the last standup, and only one of them is on your
+   roadmap.** MCP Security Whitepaper V2 merged Aug 12 and is out. The isolation blog is
+   live on the CoSAI site as of Aug 25 — I've verified it.
+
+2. **Seven deliverables in flight. One has an owner-confirmed date:** the Agent
+   Credentials paper, first draft late September. The rest are TBD, and I'd rather tell
+   you that than give you dates the owners haven't agreed to. The names who owe those
+   dates are in the doc.
+
+3. **One decision from this room unblocks the most work.** RFC #175 — is Observability a
+   top-level CoSAI-RM category or a subcategory under Application? The code is written
+   and green. Fifteen risks have nowhere to live until someone answers, and it's the same
+   blocker as agenda item 3.
+
+4. **Two structural problems I can't solve inside WS4:** the ADLC SIG lost two leads, and
+   Agent Credentials is running parallel to WS1 on verifiable claims. Both are on today's
+   agenda as items 9 and 10.
+
+5. **Ask:** add the §4 rows to the roadmap before the Sep 8 scope conversation, so WS4
+   isn't assessed on a single completed blog post.

--- a/agenda_drafts/ws4/2026-09-03.md
+++ b/agenda_drafts/ws4/2026-09-03.md
@@ -1,0 +1,359 @@
+---
+schema_version: 1
+workstream: ws4
+meeting_date: 2026-09-03
+generated_at: 2026-09-02T09:20:00Z
+generated_by: sarahnovotny
+generated_by_role: chair
+source_skill: cosai-meeting-agenda
+source_skill_version: 1.0.0
+status: draft
+promoted_to: null
+promoted_at: null
+supersedes: null
+---
+
+## Workstream 4 — Secure Design Patterns for Agentic Systems Agenda — September 3, 2026
+
+**Thursdays 12:00 ET / 09:00 PT**
+Slack: `#ws4-secure-design-agentic-systems` (cosai-op) · Mailing list: cosai-agentic-systems-ws@lists.oasis-open-projects.org
+
+---
+
+### Administrative — Deadlines and Polls
+
+| Item | Detail |
+|---|---|
+| **TSC co-chair election** | Ballot closed EOB 2026-08-28. Akila Srinivasan and J.R. Rao finish their term this month |
+| **WS1 AIMM / WS2 Zero Trust ballots** | TSC + PGB approval votes; voting members were urged to cast during w/c Aug 25 |
+| **TSC scope and roadmap realignment** | **Sep 8 TSC.** Claudia Rauch's review of scope, goals and roadmaps across all workstreams. WS4 needs a position — §1 is how we build it |
+| **TSC readout** | Deferred to **Sep 10**. The Sep 1 standup outcomes land on next week's agenda |
+| **Next week (Sep 10)** | TSC readout, plus an **ODIS update and discussion — tentatively scheduled**. Speaker and scope to confirm; flag now so anyone who wants a slot on it says so this week |
+
+---
+
+### Agenda
+
+| § | Item | Time | Lead |
+|---|---|---|---|
+| 1 | WS4 deliverables timeline — draft for discussion and refinement | 8' | Sarah Novotny |
+| 2 | Risk Map review of the MCP paper — 76 entries need WS4 reviewers (#178) | 7' | David LaBianca / Chairs |
+| 3 | **ADLC** — canonical definition, decommissioning, and the path to Risk Map controls | 10' | Emrick Donadei / Chairs |
+| 4 | Containment follow-on — **seeking a lead author** | 6' | Sarah Novotny |
+| 5 | Agent Credentials ↔ Agent Manifest ↔ WS1 | 5' | Rithikha Rajamohan / Imran Siddique |
+| 6 | WS2 telemetry — conversation and a renewed ask for reviewers | 6' | Josiah Hagen |
+| 7 | Close-outs | 4' | Chairs |
+| 8 | Written updates — no time allocated | — | — |
+
+**Total: 46'.** §8 takes no time on the call.
+
+---
+
+### §1. WS4 Deliverables Timeline — Draft for Discussion and Refinement (8') — Sarah Novotny
+
+The Aug 27 call took an action on *the group* to outline upcoming deliverables and target
+timelines. Below is the draft that went forward. **It is a straw-man, not a decision** —
+the point of this slot is for each group to correct its own rows.
+
+Two facts that frame it. First, the TSC deliverables roadmap carries **one** WS4 row: the
+agentic isolation blog, marked complete. MCP Security Whitepaper V2 shipped in August and
+was never on it at all. Second, the **Sep 8 TSC** reviews scope, goals and roadmaps across
+every workstream. If this table isn't right by then, WS4 gets assessed on a single
+completed blog post.
+
+**Shipped**
+
+| Deliverable | Evidence |
+|---|---|
+| MCP Security Whitepaper V2 | PR [#141](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/141) merged Aug 12; published and distributed on social |
+| Agentic Isolation blog — *"Treat Your Agent Like an Insider Threat: Why AI Sandboxing Can't Wait"* | PR [#167](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/167) merged Aug 25; **verified live** on coalitionforsecureai.org, dated Aug 25. The "awaiting marketing" note in the Aug 27 minutes was already stale |
+
+**In flight — correct your own row**
+
+| Deliverable | Owner | Stage | Target | Who owes the date |
+|---|---|---|---|---|
+| Observability CoSAI-RM component ([#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175)) | Parul Singh, Emrick Donadei | Implementation PR written, validating green | ~1 hour after one decision | Blocked — §3 |
+| ADLC risks and controls | ADLC SIG | 30–40 risks identified | End of August — **passed** | ADLC SIG — §3 |
+| Agent Credentials paper | Rithikha Rajamohan, Ben | Drafting by section | **Late September** | ✅ Owner-confirmed Aug 27 |
+| Multimodal threat taxonomy | Multimodal Agentic Security group | Scope agreed Aug 24 | Draft date TBD | Group, at its next weekly |
+| ADLC lifecycle definitional paper | Emrick Donadei | Drafting; ADLC P0 as of Aug 27 | **TBD** | §3 — open question on ownership |
+| Containment follow-on ([#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172)) | **Vacant** — reviewers named, no author | Scoping; 21 questions banked | **TBD** | §4 — needs a lead |
+| MCP V2.x residuals ([#163](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/163)) | Chairs | One editorial item, one chair decision | **TBD** | Chairs |
+
+**Questions for the room:**
+- Whose rows are wrong? Multimodal, Agent Credentials and ADLC each own entries here.
+- Only one deliverable has an owner-confirmed date. Which others can commit to one today?
+- **Who owns maintaining this view, and where does it live?** Asked Aug 27, still unanswered.
+  A table nobody owns will be stale again by Sep 8.
+
+---
+
+### §2. Risk Map Review — 76 MCP-Derived Entries Need WS4 Reviewers (7')
+
+*[#178](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/178), opened Aug 31 by @davidlabianca. Unlabeled.*
+
+The MCP security whitepaper has been decomposed into the CoSAI Risk Map.
+[`secure-ai-tooling#507`](https://github.com/cosai-oasis/secure-ai-tooling/pull/507) adds
+**46 new entries and updates 30 existing ones** — taking the framework from 37 to 67
+controls and 36 to 52 risks. The people best placed to check that it faithfully
+represents what the paper meant are the people who wrote the paper.
+
+**The catch worth stating aloud:** entries were decomposed in **June 2026 from the v1
+whitepaper**, with every citation line-pinned to that revision — not to the V2 that merged
+Aug 12. Finding where V2 has moved away from what an entry was derived from is explicitly
+the most valuable review outcome. One case is already known: a delegation control whose
+source text inverted its recommendation between revisions.
+
+Ten areas, exhaustive and non-overlapping. **Claim by commenting on the issue.**
+
+| Area | Entries | Issue | Volunteer |
+|---|---|---|---|
+| Identity, authentication and consent | 12 | [#512](https://github.com/cosai-oasis/secure-ai-tooling/issues/512) | |
+| Secrets and credential management | 8 | [#513](https://github.com/cosai-oasis/secure-ai-tooling/issues/513) | |
+| Authorization and delegation-chain integrity | 10 | [#514](https://github.com/cosai-oasis/secure-ai-tooling/issues/514) | |
+| Tool supply chain | 8 | [#515](https://github.com/cosai-oasis/secure-ai-tooling/issues/515) | |
+| Isolation and containment | 5 | [#516](https://github.com/cosai-oasis/secure-ai-tooling/issues/516) | |
+| Network enforcement | 5 | [#517](https://github.com/cosai-oasis/secure-ai-tooling/issues/517) | |
+| Observability, audit and accountability | 7 | [#518](https://github.com/cosai-oasis/secure-ai-tooling/issues/518) | |
+| Prompt injection and context integrity | 4 | [#519](https://github.com/cosai-oasis/secure-ai-tooling/issues/519) | |
+| The classical AI/ML estate | 13 | [#520](https://github.com/cosai-oasis/secure-ai-tooling/issues/520) | |
+| Cross-cutting *(CoSAI-RM SIG session, WS4 participation)* | 4 | [#521](https://github.com/cosai-oasis/secure-ai-tooling/issues/521) | |
+
+**Ask:** fill the Volunteer column. Areas 3, 5 and 7 map onto work WS4 members are already
+deep in — delegation, containment, observability. Label #178 before it goes stale.
+
+---
+
+### §3. ADLC — Canonical Definition, Decommissioning, and the Path to Risk Map Controls (10') — Emrick Donadei / Chairs
+
+*Merges what were three separate items. They are one argument, and taking them apart is
+why none of them has moved.*
+
+**The sequencing the Aug 27 call agreed:** *the ADLC group's priority is the definitional
+agentic development life cycle paper, rather than the containment paper.* A lifecycle you
+have not defined cannot have phases added to it, and risks cannot be mapped onto stages
+that do not yet exist. Everything below follows from that order.
+
+#### 3a. Who owns a canonical ADLC definition / landscape paper?
+
+**This is the open question of the meeting.** Emrick is drafting an anchor paper —
+lifecycle definition, terminology, phases — but the SIG lost two leads to work changes,
+the action to find two meeting leads a month is **3 meetings old and unfilled**, and the
+SIG paused RFC work pending a chair check-in.
+
+- Is this Emrick's paper, the SIG's paper, or a WS4 paper the SIG contributes to?
+- Who are the ADLC leads going forward? Without an answer, the timeline question below
+  has no one to answer it.
+- **What date goes against the definitional paper?** Emrick holds an open action to set
+  it. This is the single most useful thing to land on this call.
+- Is it a *definition* paper or a *landscape* paper — do we describe the lifecycle we
+  believe in, or survey the ones in use? They are different documents with different
+  review burdens.
+
+#### 3b. Decommissioning — the first test of the definition
+
+*[#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) `review` · Bill Stout.*
+
+Proposes decommissioning as an ADLC phase and CoSAI lifecycle stage 9 — data deletion,
+credential cleanup, PII removal. The Aug 26 ADLC session rescoped it to **hard
+decommissioning only**; soft decommissioning was dropped because legal-hold requirements
+mandate archiving copies for forensics. Hard decommissioning may still require sealing or
+archival to satisfy forensic and record-keeping obligations — deletion is not the whole of it.
+
+David LaBianca objects to adding a phase before ADLC publishes foundational documents.
+**Under 3a's sequencing that objection is a schedule, not a veto:** decommissioning is the
+first proof that the definitional paper is complete enough to extend.
+
+- Chair decision: accept stage 9 now, or land it with the definitional paper?
+- Bill's RFC edit stripping soft decommissioning — landed?
+- Raymond Sheh's review against his notes — done?
+
+#### 3c. Then the Risk Map controls open up
+
+Once stages are defined, risks and controls have somewhere to attach. Two things are
+queued behind that and one is blocked on a single question.
+
+| Item | State |
+|---|---|
+| **Observability component** ([#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175)) | [`secure-ai-tooling#501`](https://github.com/cosai-oasis/secure-ai-tooling/pull/501) is written and validates green. Waits on **one** question: top-level CoSAI-RM category, or subcategory under Application? ~1 hour of work once answered, ~1 day for the 8-risk catalog. **~15 observability risks have no correct home**, and Runtime/Reflection risk drafting is blocked behind it |
+| **ADLC risks and controls** | 30–40 risks identified. End-of-August deadline passed — blocked on #175 and the leadership gap in 3a |
+
+**Also unresolved:** does [`secure-ai-tooling#473`](https://github.com/cosai-oasis/secure-ai-tooling/pull/473)
+(17 components, @davidlabianca) already cover Observability? If it is a partial match the
+two need reconciling before either lands. With #507 from §2, **three open PRs are now
+editing the same corpus** — worth a coordination call with the CoSAI-RM SIG.
+
+Emrick's broken cross-repo links, raised Aug 26 — fixed?
+
+---
+
+### §4. Containment Follow-On — Seeking a Lead Author (6') — Sarah Novotny
+
+*[#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172) — 21 scope questions banked from the #167 review.*
+
+**This is a recruiting item.** The paper has reviewers and no author.
+
+| Have | Missing |
+|---|---|
+| TSC reviewers named Aug 25: **Akila Srinivasan, David LaBianca, Jodi Middleton (NVIDIA)** | **A lead author** |
+| 21 scope questions banked with attribution in #172 | An outline and section owners |
+| A published blog making the case, and an existing isolation cookbook | A target date |
+
+**The ask: someone to lead this paper, working with Ian Molloy and the named reviewers.**
+Not a solo write — the job is holding the outline, chasing section owners, and deciding
+what the paper argues. Contributors who have already done the thinking here and would be
+natural section owners: @skvcool-rgb (offered a subsection on aggregate consumption across
+a set of agents), @getglad (tool/MCP call as the mediation surface), Laura Seletos and
+John Cavanaugh (detection patterns a SOC can actually implement).
+
+**Placement, for the lead to inherit settled:** the ADLC SIG is a *process* group; a
+technical how-to containment paper is an *implementation* artifact. Raghuram Yeluri and I
+flagged the mismatch Aug 27. WS4's position: ADLC owns the definitional paper (§3), a
+broader workstream owns containment plus its technical playbooks.
+
+**Two structural questions the lead should answer first** — the other 19 can't be settled
+until these are:
+- **Q1** — is containment a standalone control family, or one layer of a bounded-authority
+  model that should be presented whole? Two reviewers arrived here independently.
+- **Q5** — what audience? Practitioner, architect, or executive? Asked by
+  @Johncavanaugh-IIS and never answered.
+
+---
+
+### §5. Agent Credentials, Agent Manifest, and WS1 (5') — Rithikha Rajamohan / Imran Siddique
+
+**Agent Credentials paper** — the only WS4 deliverable with an owner-confirmed date:
+**first draft late September**, reconfirmed Aug 27. The Aug 27 session reached consensus
+that appraisal is not required, and redefined a credential as *a signed claim bound to a
+subject and intended for downstream verification*. Sections 1 and 5 get a group review.
+Abhijeet Kolekar flagged AI-generated text citing RFCs incorrectly — worth noting for our
+own AI-usage practice.
+
+**Three convergence questions, all live:**
+
+1. **Manifest into Credentials?** [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149) Phase 2. Imran joined the credentials call Aug 27 to align. Schema unification was assigned to the Agent Credential group Aug 20 and is **2 meetings carried**.
+2. **WS1 bridge.** Kapil proposed merging parallel verifiable-claims threads to avoid fragmented, piecemeal output; WS1 is exploring transportable evidence for AI/ML artifacts. Nicolai Nielsen recommended consulting Claudia. Rithikha holds the action to raise it here.
+3. **Verifier ↔ trace architecture.** Imran and Raghuram Yeluri to reconcile the manifest verification architecture with trace-generation outputs — carried from Aug 27.
+
+**Carried and overdue:** Imran's Agent Card integration update and standards-integration
+diagram (2 meetings); the **Phase 1 disposition summary is 4 meetings and 26 days overdue**.
+Daniel Major's manifest review is 3 meetings carried.
+
+---
+
+### §6. WS2 Telemetry — Conversation and a Renewed Ask for Reviewers (6') — Josiah Hagen
+
+Josiah joins to walk WS4 through the telemetry working document. This was raised on last
+week's agenda and produced no WS4 reviewers, so it comes back with a name attached.
+
+**Where it stands.** The telemetry group added three risks and a control following the MCP
+review, and presents the document as a **working map for aligning changes with OCSF and
+OpenTelemetry**. OCSF collaboration is active. Josiah has asked members working on ODIS or
+other telemetry standards to help fold reference attacks into the CoSAI risk map. The
+Telemetry Paper sits on the TSC roadmap as WS2, in progress, next milestone TSC co-chairs
+review, no date. Separately, the TSC is settling how WIP telemetry work gets labelled in
+public repos as the paper migrates to GitHub.
+
+**Why WS4 specifically.** Telemetry is where three WS4 threads land at once: the
+observability component in §3c, the observability/audit review area in §2, and the
+detection-patterns gap Matthew Gladney and Laura Seletos raised Aug 27 — SOC teams lacking
+the telemetry to detect agent misbehaviour, needing network logs plus full OpenTelemetry
+tracing plus correlated sources, with prompt and response sanitization unaddressed. **That
+gap has no home in WS4 today.** This conversation is the natural place to test whether it
+belongs to WS2's telemetry work or to the containment follow-on in §4.
+
+**The ask — and it is specific.** Reviewers are wanted for *actionable, rephrased editing
+suggestions*, not high-level critique. Add your name **and a timeline** in the document.
+Bill Stout's edits on other documents are the model.
+
+| Reviewer | Section / lens | Committed by |
+|---|---|---|
+| | | |
+
+---
+
+### §7. Close-Outs (4') — Chairs
+
+**[#156](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/156) contributor screening** — the Aug 20 call decided against running the automation in
+CoSAI repos; Imran closed PR #157 and rewrote #156 as a reference runbook. Still open,
+unlabeled, unassigned — **33 days**. Accept as a documented pattern, or decline? Either
+way, label it and close the thread.
+
+**[Discussion #129](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/129)** — 21 comments, last activity Aug 28, never dispositioned.
+
+**[#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) summary** — closed Aug 13 after 102 comments. The action to relocate the useful content
+to a permanent document is assigned to *the group*, which means nobody. 2 meetings carried.
+**Needs a name and a destination.**
+
+**Meeting links for public contributors** — Matthew Gladney asked Aug 27 where external
+contributors find active discussion without joining every meeting. Sarah's action: add
+Slack channels and meeting info to the agenda. Small, and it is the concrete half of the
+GitHub-first decision.
+
+---
+
+### §8. Written Updates — No Time Allocated
+
+| Topic | Status |
+|---|---|
+| **GitHub-first decision** | Recorded Aug 27: primary communication and decision-making moved to GitHub — Slack is not durable for OASIS governance. Slack stays for topic chat |
+| **Multimodal Agentic Security** | Scope agreed Aug 24 ([Discussion #173](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/173)): **threat taxonomy, not mitigations**; 7-layer agentic stack mapped, with perception, model, tool-use and output layers highest-exposure. Scope restricted to statistical and neural models; neuro-symbolic deferred. **Confirm scope is closed, and set a draft date** (§1) |
+| **ODIS** | An update and discussion is **tentatively scheduled for Sep 10** — confirm the speaker and scope this week. The Aug event was held Aug 27 or 28 (the two sets of minutes disagreed) at NVIDIA and still has no readout; @nirpaz owes a remote link (2 meetings) and a README PR (3 meetings). Both fold into next week's slot |
+| **Isolation blog** | ✅ Live at coalitionforsecureai.org since Aug 25. Promotion copy with Mary Beth still outstanding |
+| **Stale PRs** | [#116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) identity playbook (Jun 10) · [#92](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/92) AI usage policy (May 5, **105 commits behind main** — needs a rebase before merge) · [#89](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/89) MCP conformance guide (Apr 28) · [#72](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/72) practical guide patterns (Apr 7) |
+| **Trace → Linux Foundation** | Imran Siddique transferred the Trace project to the LF; noted Aug 27 |
+
+---
+
+### Action Item Follow-ups
+
+| Owner | Action | Status |
+|---|---|---|
+| The group | Prepare the TSC report — deliverables and target timelines | ✅ **Done** — presented Sep 1; the draft is §1 for refinement |
+| Rithikha Rajamohan | Set a target date for the first agentic paper draft | ✅ **Done** — late September confirmed Aug 27 |
+| Claudia Rauch (OASIS) | Publish the isolation blog to the CoSAI website | ✅ **Done** — verified live, dated Aug 25 |
+| Ian Molloy | Draft social copy for the blog | ✅ **Done** (Aug 27) |
+| Sarah Novotny | Discuss containment-paper placement with David LaBianca | 🔄 **On this agenda** (§4) |
+| Sarah Novotny | Coordinate ADLC leadership with Emrick Donadei *(second name garbled in the minutes as "Jennings" — confirm)* | 🔄 **On this agenda** (§3a) |
+| Sarah Novotny | Audit #163 for whether V2.x needs a follow-on version | ❓ Not started |
+| Sarah Novotny | Add Slack and meeting links to the agenda for public contributors | ❓ New (Aug 27) — §7 |
+| Sarah Novotny | Present the telemetry documentation to WS4 | ✅ **Done** → §6, with Josiah Hagen leading |
+| Emrick Donadei | Draft the lifecycle definitional paper | 🔄 In progress — §3a |
+| Emrick Donadei | **Set the timeline for the definitional paper** | ❓ New (Aug 27) — the ask of the week (§3a) |
+| Emrick Donadei | Fix the broken cross-repo links in the PR | ❓ Raised Aug 26 (§3c) |
+| Bill Stout | Strip soft-decommissioning from RFC #170 | 🔄 In progress — rescoped Aug 26 (§3b) |
+| Raymond Sheh | Review RFC #170 against his notes | 🔄 In progress — committed Aug 26 |
+| David Pierce | Define risk patterns with Laura Seletos (CoSAI-RM, pattern definitions) | ❓ New (Aug 27) — *minutes record this as "Isaac Pierce"* |
+| Laura Seletos | Review the WS2 containment and observability working document | ❓ New (Aug 27) — §6 |
+| The group | Review the telemetry working document — actionable edits, add name + timeline | 🔄 **On this agenda** (§6) |
+| The group | Review the Agent Manifest RFC and give critical feedback in the linked doc | ❓ New (Aug 27) |
+| Imran Siddique, Raghuram Yeluri | Reconcile the verifier / trace-generation architecture | ❓ New (Aug 27) — §5 |
+| Imran Siddique, Rithikha Rajamohan | Merge Agent Manifest concepts into the credentials proposal | ❓ New (Aug 27) — §5 |
+| Imran Siddique | Update the RFC re: Agent Card integration | ⚠️ Carried Over — 2 meetings (since Aug 20) |
+| Imran Siddique | Draft the standards-integration diagram | ⚠️ Carried Over — 2 meetings (since Aug 20) |
+| Imran Siddique | Post the Phase 1 disposition summary | ⚠️ Carried Over — **4 meetings, 26 days overdue** (since Aug 9) |
+| Agent Credential group | Unify Manifest and Credential schemas | ⚠️ Carried Over — 2 meetings (since Aug 20) |
+| Daniel Major | Review the Agent Manifest proposal | ⚠️ Carried Over — 3 meetings (since Aug 13) |
+| The group | Summarize [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) into a permanent document | ⚠️ Carried Over — 2 meetings; **unowned** (§7) |
+| The group | Volunteer to lead two ADLC meetings a month | ⚠️ Carried Over — 3 meetings; still unfilled (§3a) |
+| Nir Paz | Share the ODIS remote link | ⚠️ Carried Over — 2 meetings |
+| Nir Paz | ODIS README PR | ⚠️ Carried Over — 3 meetings |
+| Claudia Rauch (OASIS) | Coordinate blog promotion with Mary Beth | ❓ Unknown |
+| **Unassigned** | Claim Risk Map review areas in [#178](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/178) | ❓ **New — main ask of §2** |
+| **Unassigned** | **Lead the containment follow-on paper** | ❓ **New — main ask of §4** |
+
+**Status Key:** ✅ Done · 🔄 In Progress · ⚠️ Carried Over · ❓ Unknown
+
+Done items stay on this agenda for visibility and drop off next week.
+
+---
+
+### Reference Materials
+
+- [`agenda_drafts/ws4/2026-09-01-tsc-report.md`](./2026-09-01-tsc-report.md) — what WS4 put in front of the TSC on Sep 1; §1 is its table
+- [Discussion #177](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/177) — WS4 agenda, Aug 27
+- [Discussion #174](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/174) — ADLC SIG agenda, Aug 26
+- [Discussion #173](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/173) — Multimodal Agentic Security, Aug 24
+- TSC minutes, Aug 25 · TSC meeting planner, [Sep 1](https://github.com/cosai-oasis/cosai-tsc/blob/main/TSC%20Meeting%20Planner%20and%20Tracker/meetings/2026-09-01.md)
+- [TSC deliverables roadmap](https://github.com/cosai-oasis/cosai-tsc/blob/main/TSC%20Deliverables/roadmap.md) — one WS4 row as of Sep 1
+- [`secure-ai-tooling#507`](https://github.com/cosai-oasis/secure-ai-tooling/pull/507) · [`#501`](https://github.com/cosai-oasis/secure-ai-tooling/pull/501) · [`#473`](https://github.com/cosai-oasis/secure-ai-tooling/pull/473) — three open PRs against the same Risk Map corpus


### PR DESCRIPTION
Two drafts, both `status: draft` and neither promoted to a Discussion.

## `agenda_drafts/ws4/2026-09-01-tsc-report.md`

Discharges the Aug 27 action on the group to *"outline upcoming project deliverables and target timelines to present at the September 1 meeting"* — TSC agenda item 8.

Two shipped deliverables, seven in flight, four asks. Only the Agent Credentials paper carries an owner-confirmed date (late September, reconfirmed Aug 27); everything else is marked TBD against the name who owes the date rather than given an inferred target.

It also supplies rows in `cosai-tsc` roadmap format. Going into Sep 1 the TSC deliverables roadmap carried **one** WS4 row — the agentic isolation blog, marked complete — and MCP Security Whitepaper V2 was not on it at all.

One correction recorded: the Aug 27 minutes describe the isolation blog as "awaiting marketing committee posting." That was already stale — the post has been live on the CoSAI site since Aug 25.

## `agenda_drafts/ws4/2026-09-03.md`

Agenda for Thursday. Notable changes from the Aug 27 draft:

- **ADLC consolidated.** Three items that had been carried separately since August merge into one section, ordered by the sequencing the Aug 27 call agreed: the definitional lifecycle paper, then decommissioning as a lifecycle stage, then Risk Map controls. Open question at the top — who owns a canonical ADLC definition/landscape paper, and what date goes against it.
- **Containment follow-on is now a recruiting item.** Reviewers were named at the Aug 25 TSC; there is no lead author. The ask is someone to lead it with @imolloy and the named reviewers.
- **New:** the CoSAI Risk Map review of the MCP paper (#178) — 76 entries across ten non-overlapping areas, with a volunteer column to fill on the call.
- **New:** a WS2 telemetry conversation led by Josiah Hagen, with a renewed and more specific ask for reviewers.
- Sep 1 TSC readout defers to Sep 10, where an ODIS update is tentatively scheduled.

## Sources

2026-08-27 WS4 minutes, 2026-08-25 TSC minutes, the Sep 1 TSC meeting planner, and live issue/PR state as of 2026-09-02.

## AI assistance

Claude Code (Opus 5) drafted both documents end-to-end from the minutes and live repository state, under my direction on structure and framing. I reviewed and revised before commit. Per the WS4 `CONTRIBUTING.md` AI usage policy and the OASIS CoSAI AI Usage Guidelines.