### PR TITLE
docs(agenda): add WS4 agenda draft for 2026-09-10

### DIFF
--- a/agenda_drafts/ws4/2026-09-10.md
+++ b/agenda_drafts/ws4/2026-09-10.md
@@ -1,0 +1,480 @@
+---
+schema_version: 1
+workstream: ws4
+meeting_date: 2026-09-10
+generated_at: 2026-09-08T11:45:00Z
+generated_by: sarahnovotny
+generated_by_role: chair
+source_skill: cosai-ws4-meeting-agenda
+source_skill_version: 1.0.0
+status: draft
+promoted_to: null
+promoted_at: null
+supersedes: null
+---
+
+## Workstream 4 — Secure Design Patterns for Agentic Systems Agenda — September 10, 2026
+
+**Thursdays 12:00 ET / 09:00 PT**
+Slack: `#ws4-secure-design-agentic-systems` (cosai-op) · Mailing list: cosai-agentic-systems-ws@lists.oasis-open-projects.org
+New to the workstream? Start with the [CoSAI onboarding guide](https://github.com/cosai-oasis/oasis-open-project/blob/main/ONBOARDING.md) — mailing list, meeting invitations and Slack.
+
+---
+
+### Administrative — Deadlines and Polls
+
+| Item | Detail |
+|---|---|
+| **WS2 telemetry feedback closes** | **Monday 2026-09-14.** GitHub issues or PRs against [`ws2-defenders/telemetry/CoSAI-AI-Telemetry-RFC.md`](https://github.com/cosai-oasis/ws2-defenders/blob/main/telemetry/CoSAI-AI-Telemetry-RFC.md). Josiah Hagen wants TSC co-chair review the week of Sep 15 — §6 |
+| **Containment contributions open** | Contributions close **2026-10-08**, first draft to reviewers **2026-10-15**, review-ready **2026-10-29**. Dates set by the editor in [#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172) — §3 |
+| **New TSC co-chairs seated** | J.R. Rao (IBM), Jodi Middleton (NVIDIA), Karttik Panda (OpenAI), Jason Garman (Amazon). |
+| **ADLC SIG co-lead consensus closes** | **Friday 2026-09-11, 6pm ET** — tomorrow. Two nominees: **Courtenay Ngo** (Microsoft) and **Matthew Gladney** (NVIDIA). TSC voting members only; absent an objection, consent is assumed — §4a |
+| **WS1 AIMM and WS2 Zero Trust papers** | ✅ **Both approved by the PGB without objection on Sep 7** and ready for publication; workstream leads asked to convert to PDF with Ian's tool. [Zero Trust for AI Systems](https://github.com/cosai-oasis/ws2-defenders/blob/main/zero-trust/Zero%20Trust%20for%20AI%20Systems.md) is now a CoSAI Release and is required reading for the containment authors |
+
+---
+
+### Agenda
+
+| § | Item | Time | Lead |
+|---|---|---|---|
+| 1 | **ODIS — readout from the Aug 28 kickoff, and work going forward** | **20'** | Nir Paz / Matthew Gladney (NVIDIA) |
+| 2 | TSC readout — Sep 1 and Sep 8 | 6' | Sarah Novotny |
+| 3 | Containment follow-on — editor named, contributions open | 6' | Jeff Leva |
+| 4 | ADLC — leadership, decommissioning, observability | 8' | Chairs |
+| 5 | Risk Map review of the MCP paper — still zero volunteers (#178) | 5' | Chairs / David LaBianca |
+| 6 | WS2 telemetry — feedback closes Monday | 4' | Chairs |
+| 7 | Close-outs | 4' | Chairs |
+| 8 | Written updates — no time allocated | — | — |
+
+**Total: 53'.** §1 has the floor; if we run long, §5 and §7 compress.
+
+---
+
+### §1. ODIS — Readout from the Aug 28 Kickoff, and Work Going Forward (20') — Nir Paz / Matthew Gladney
+
+*Announced on the Sep 3 call: "we're going to have an ODIS readout from the event and the work
+going forward … next week will specifically be ODIS." This is that slot. Nir Paz hosted the
+kickoff at NVIDIA on Friday Aug 28; it has had no readout to this group.*
+
+**Suggested shape — 10' readout, 10' discussion.** The discussion half matters as much as the
+readout: WS4 has three efforts sitting on the same ground and no written mapping between any of
+them and ODIS.
+
+#### 1a. Readout (10')
+
+What the group needs out of the kickoff, in rough priority order:
+
+| Question | Why it matters here |
+|---|---|
+| What was decided at the event, and what changed from the June 25 presentation? | The last WS4 exposure was [Discussion #127](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/127), June 25 |
+| What is the venue and governance path? | Open-sourcing the spec and finding a standards home were stated intentions in June; the TSC is tracking this separately ([cosai-tsc#62](https://github.com/cosai-oasis/cosai-tsc/issues/62), Jodi Middleton), and he reported at the Sep 8 TSC that he is **preparing a meeting with his team on ODIS**. The TSC track and this readout are moving in parallel — worth deciding here what each is for |
+| What is the current spec status, and what is stable enough to build against? | Matthew Gladney's caution on Sep 3 was explicit: *"ODIS is far from being stable on its spec, so I wouldn't over-index on what it will and won't deliver just yet"* |
+| Who is implementing, and against which layer? | Reference implementations were "in flight with several partner organizations" as of June |
+| Is there a cross-vendor collaboration cadence? | Nir floated one in June, in the spirit of how SPIFFE was developed. Interest in the room is a useful signal to take back |
+
+**Recap for people new to ODIS**, so the readout does not spend its ten minutes on
+re-introduction. ODIS — the Open Delegation & Identity Standard — is a proposed vendor-neutral
+architecture for cryptographic identity, delegation and governance for agents crossing enterprise
+trust domains. It is deliberately an overlay, "an opinionated contract between technologies,"
+augmenting OAuth 2.0/OIDC, SPIFFE/SPIRE, SCIM and existing policy engines rather than replacing
+them. Three layers:
+
+- **Passport** — identity and attestation. Binds software provenance and runtime/workload
+  attestation into a short-lived, holder-bound agent runtime credential. No static secrets.
+- **Bridge** — delegation and access. Carries who the agent acts for and what authority was
+  delegated, and translates it into credentials downstream systems already understand.
+- **Router** — discovery and governance. Where the agent may go, with revocation and kill-switch
+  semantics; feeds policy engines rather than competing with them.
+
+Four pillars: delegated user identity, agent code/package identity, agent runtime instance
+identity, and cascaded multi-agent delegation. The commitment that drew most discussion in June
+was **semantic attenuation** — a sub-agent's authority must be equal to or narrower than its
+parent's across resources, actions and constraints, not merely a smaller scope-string set.
+
+#### 1b. Discussion (10')
+
+**The WS4-side question first, because it is ours and not the presenters':** ODIS overlaps at
+least four active WS4 efforts and there is no written mapping to any of them.
+
+| WS4 effort | Overlap with ODIS |
+|---|---|
+| Identity Architecture Patterns playbook ([PR #116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116)) | Passport / Bridge / Router sit almost on top of the playbook's pattern set. **The PR is unattended since its author's reassignment** — §7 |
+| [Agentic Identity and Access Control paper](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/blob/main/whitepapers/agentic-identity-and-access-control.md) | Published, same problem space, no explicit mapping |
+| Agent Credentials | Kapil Singh, Sep 3: *"Agent Credentials thread deals with identity components too, and several participants there also contributed to the published CoSAI identity whitepaper"* |
+| Trust Graph | Delegation-chain records ≈ non-repudiable who-delegated-what-to-whom lineage |
+
+**Ask: one person to own an ODIS ↔ WS4 mapping note.** Not a deliverable — a page saying which
+ODIS concept corresponds to which WS4 artifact and where they diverge. Jeff Leva's interop
+document (§7) is the obvious place for it to live.
+
+**Threads carried from June 25, unanswered.** Named so the people who raised them can pick them
+back up:
+
+1. **Chain-of-authority reasoning** (Mayur Agnihotri) — do delegation records carry enough
+   metadata for a policy engine to reason over the *entire* chain, not just the last hop?
+2. **Semantic attenuation in practice** — how is "semantically narrower" verified across
+   heterogeneous token carriers and provider adapters, where a lexical scope-subset check is not
+   sufficient?
+3. **Forensics and undo** (Bill Stout) — what must the delegation and audit trail capture to
+   support post-incident reconstruction, and eventually rollback or redo?
+4. **Per-session parameterization** (David Pierce) — binding delegated authority to a specific
+   session or task instance was not implemented; what should the contract say?
+5. **Revocation across vendors** — what is realistically achievable today for revocation
+   propagation across multi-hop, multi-vendor chains?
+6. **Spec boundary** (Jeff Leva / Matthew Gladney) — ODIS as a GraphQL-like opinionated contract:
+   what belongs in the specification versus in implementations?
+
+**Two new ones from Sep 3:**
+
+7. **Lifecycle, not just identity** — Bill Stout: *"ODIS talks about identity, however not yet
+   like a synthetic persona, not yet a formal onboarding/offboarding process defined."* Onboarding
+   and offboarding an agent identity is exactly what the decommissioning work in §4 is trying to
+   pin down. If ODIS is silent there, that is a gap worth naming while the spec is still moving.
+8. **Reference attacks into the Risk Map** — Josiah Hagen has asked members working on ODIS or
+   other telemetry standards to help fold reference attacks into the CoSAI Risk Map. §6.
+
+> **Housekeeping.** The ODIS reference document is a
+> working draft that is not public, and shared for comment rather than circulation. **Do not put
+> the document link on a public thread** without Nir and Matthew's agreement. Same for slides.
+> This should  be addressed and moved to CoSAI GH or Google Docs.
+
+---
+
+### §2. TSC Readout — September 1 and September 8 (6') — Sarah Novotny
+
+**Sep 1, settled.** Two of WS4's four asks came back closed:
+
+| Ask | Outcome |
+|---|---|
+| Where does the containment paper live? | **Broad WS4 workstream, not the ADLC SIG.** Settled; §3 proceeds on that basis |
+| Should Agent Credentials fold into WS1? | **No.** TSC declined to fold the group. The work product incorporates WS1's findings; schemas are being defined with OCSF |
+
+Also from Sep 1: four co-chairs elected; AIMM and Zero Trust approved and at PGB; the arXiv
+publication proposal was discussed and closed; regional meetups deferred to the PGB; and Jason
+Garman is scoping a one-page proposal on an industry framework for AI jailbreaks, back to the TSC
+in four to six weeks. **David LaBianca raised ODIS follow-up at the TSC** — [cosai-tsc#62](https://github.com/cosai-oasis/cosai-tsc/issues/62)
+now tracks it, with Jodi Middleton syncing for a future TSC agenda item — he reported on Sep 8
+that he is preparing that meeting. §1 is the WS4 half of it.
+
+**Sep 8 — no quorum, so the big item did not happen.** J.R. Rao and Akila Srinivasan were both
+absent and the three new co-chairs ran the meeting. Karttik Panda **postponed the detailed
+workstream status reviews to the next call**, when J.R. is present. What that means for WS4:
+
+| Item | Where it landed |
+|---|---|
+| **Scope, goals and roadmap reassessment** ([cosai-tsc#52](https://github.com/cosai-oasis/cosai-tsc/issues/52)) | **Deferred.** WS4's position is unchanged and unheard: the problem is not scope, it is that we don't have a clear map of today's work efforts. The proposal is that each workstream produces an owned map of its internal efforts once a co-chair term, rather than renegotiating remit |
+| **End-of-term workstream standup** ([cosai-tsc#49](https://github.com/cosai-oasis/cosai-tsc/issues/49)) | **Deferred with it.** Sarah gave a short verbal update — containment has an owner, Agent Credentials is October — and pointed at the deliverables PR |
+| **ADLC SIG leadership** ([cosai-tsc#63](https://github.com/cosai-oasis/cosai-tsc/issues/63)) | ✅ **Resolved — see §4a.** Two volunteers introduced; the consensus call went to the mailing list precisely because the room lacked quorum. Separately, **Courtenay Ngo has taken the definitional paper as lead editor** — the workstream's largest unowned dependency now has a pen |
+| **Meeting time** | Karttik raised a standing conflict and David LaBianca argued for a slot that reaches Asia. Sarah/David LaBianca proposed/supported an **alternating schedule** for European and Asian time zones. Co-chairs to agree candidate slots, then Claudia polls the TSC. Watch for it |
+| **Repository access and AI-generated content** ([cosai-tsc#29](https://github.com/cosai-oasis/cosai-tsc/issues/29)) | OASIS is drafting policy to curb AI slop in issues and discussions. Josiah Hagen proposed requiring iCLA verification to establish accountability; automated AI-content detection was judged ineffective, leaving maintainers on manual sniff tests. **Sarah took an action to assess #29 and evaluate a workstream best-practices document** — §7 |
+| Telemetry paper migration ([cosai-tsc#51](https://github.com/cosai-oasis/cosai-tsc/issues/51)) | Closed; superseded by [cosai-tsc#67](https://github.com/cosai-oasis/cosai-tsc/issues/67) — §6 |
+
+---
+
+### §3. Containment Follow-On — Editor Named, Contributions Open (6') — Jeff Leva
+
+**This item changed character since Sep 3. It was a recruiting ask; it is now a work item with an
+editor, a structure, and three dates.**
+
+Jeff Leva volunteered on the Sep 3 call, declared himself Editor on Sep 5, and is assigned on
+[#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172).
+
+| | |
+|---|---|
+| **Skeleton** | [PR #181](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/181) → `whitepapers/agent-containment.md`. All 21 scope questions from #172 mapped to sections, each naming the reviewers who raised them as contributors. **merged** — contributions have somewhere to land |
+| **How to contribute** | By PR against a section, by comment, or by handing the editor notes. Sections 1, 2, 5 and 7 are the priority; the rest hang off them. To own a section outright, say so |
+| **Dates** | Contributions **2026-10-08** · first draft to TSC reviewers **2026-10-15** · review-ready **2026-10-29** |
+| **Reviewers** | Akila Srinivasan, David LaBianca, Jodi Middleton — named by the TSC on Aug 25. **None has been formally requested on PR #181** |
+| **New contributor** | **Jason Bowman** — security and RL-agent background, introduced by Kevin Calloway on Sep 3, attended the call, gave Claudia his email. Needs Slack access and an introduction to Jeff |
+
+**Q21 is delivered, and one finding is worth the room's attention.** Working the "read the primary
+sources" question, Jeff found the published blog conflates two separate intrusions — the JFrog
+Artifactory CVEs and the Hugging Face data-pipeline compromise are different events with different
+vulnerability sets. **Chair decision, recorded:** this is corrected in the follow-on paper, not by
+amending the live post. The blog stands as published; §6 of the paper carries the accurate account
+of both. John Cavanaugh's three-page comparison of the blog against the OpenAI incident report is
+attached to #172 and lands in the same section.
+
+**Two structural questions the room can help close** — the other 19 sequence behind them:
+- **Q1** — is containment a standalone control family, or one layer of a bounded-authority model
+  that should be presented whole? Two reviewers arrived here independently.
+- **Q5** — practitioner, architect, or executive? Asked by John Cavanaugh, still unanswered.
+
+**Vocabulary alignment with WS2 Zero Trust is cheaper now than after both ship.** Josiah flagged
+it in chat on Sep 3; the paper publishes imminently.
+
+---
+
+### §4. ADLC — Leadership, Decommissioning, Observability (8') — Chairs
+
+#### 4a. Leadership — two co-lead volunteers, and an editor for the definitional paper
+
+**This resolved between the Sep 3 call and today.** Sarah introduced two volunteers at the Sep 8 TSC:
+
+| Nominee | Organisation | Also taking on |
+|---|---|---|
+| **Courtenay Ngo** | Microsoft | **Lead editor, ADLC definitional paper** — see below |
+| **Matthew Gladney** | NVIDIA | *Presenting §1* |
+
+The room lacked quorum, so Claudia posted a **call for consensus to the TSC list** instead. TSC
+voting members only; objections close **Friday 2026-09-11, 6pm ET**, and absent an objection
+consent is assumed. That is tomorrow — if anyone here has a view, it needs to reach a voting
+member today.
+
+**Sarah led yesterday's ADLC session** to transition both of them in. Assuming consent, the
+SIG goes from one and a half co-chairs to three and a half.
+
+**And the definitional paper has a lead editor: Courtenay Ngo.**
+
+This is the bigger of the two pieces of news, and it is a separate thing from the co-lead
+nomination — editing the paper is not the SIG lead's job by default, a conflation I made on the
+Sep 3 agenda and corrected on the call. Emrick Donadei leads the *SIG*; Courtenay holds the pen on
+the paper.
+
+**Why it matters more than it sounds.** The definitional lifecycle paper was the single largest
+unowned dependency in the workstream. Both remaining ADLC work products sequence behind it — the
+risks-and-controls catalogue and the CoSAI-RM integration — and so does the decommissioning
+question in 4b. The SIG has written 25,000 words of the *downstream* artifact while the upstream
+anchor sat empty. That inverts today.
+
+**What the room can usefully give the editor:**
+- Is it a *definition* paper or a *landscape* paper — do we describe the lifecycle we believe in, or survey the ones in use? Different documents, different review burdens, and it has never been settled.
+- A target date, once they have read in. Nothing downstream can be scheduled until this one is.
+- Section contributors. Named phase owners already exist in the SIG's working set.
+
+Worth stating plainly what the editor inherits: one reassignment orphaned the ADLC scope doc, an
+accepted RFC ([#50](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/50), committed as `RFCs/RFC-50.md`), the open identity playbook
+[PR #116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116), and this paper. Four artifacts across three deliverables, and two of the four
+now have someone attending them again.
+
+#### 4b. Decommissioning ([#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170)) — converging, and a resolution path emerged
+
+Bill Stout's RFC has moved substantially and the thread is coalescing on a definition proposed by
+Imran Siddique on Sep 3:
+
+> Decommissioning **ends the agent's authority to act**; whether it can come back later is a
+> policy choice, and if it comes back it re-enters through Admission as a new entity.
+
+- ✅ **The soft/hard split is struck through in the RFC body** — Bill's Aug 26 rescoping edit
+  landed. Bill raised on Sep 3 that soft and hard still need *organizational* definitions,
+  analogous to how NIST SP 800-53 parameters are set locally rather than centrally.
+- Raymond Sheh added wider-system dependency and institutional-knowledge risks — what breaks
+  downstream when an agent other systems depend on is retired.
+- **The resolution path from Sep 3:** put decommissioning into the definitional paper *as a phase*,
+  so end-of-life risks have somewhere to attach. Bill's framing — *"there is need of a place to
+  land."* That turns David LaBianca's sequencing objection from a standing disagreement into
+  another dependency on 4a. **It also means the objection is answered by writing the paper, not by
+  arguing about the RFC — and as of today the paper has an editor, so the dependency has somewhere
+  to sit.** Bill Stout and Courtenay Ngo should talk.
+- The separate change — adding `decommissioning` as order 9 in the CoSAI Risk Map lifecycle stages
+  — stays on its own RFC track and needs Risk Map owners, not only this SIG.
+
+**Chair decision:** ACCEPT the phase into the definitional paper's scope, and hold the risk catalogue until that paper publishes.
+
+#### 4c. Observability ([#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175)) — the question is moot; the RFC is being withdrawn
+
+Emrick went looking and found the existing **`AuditRecordRepository`** component in the Risk Map
+already covers semantic observability — *"can we reconstruct what happened."* His own conclusion,
+posted Sep 1:
+
+> My suggestion then, we can probably drop that RFC, and instead reframe it to the creation of a
+> control.
+
+What is *not* covered is behavioural observability — *"should we intervene?"*: baselines, drift and
+tool-usage anomaly detection, circuit breakers, kill switches, escalation gates. That half gets
+refiled as a **control** against the existing component.
+
+**This closes the top-level-category-or-subcategory question that has been on three agendas.** It
+was already superseded before it was last asked. The remaining ask is one comment from the chairs
+and the CoSAI-RM SIG confirming the withdrawal and the reframe, which unblocks ADLC risk drafting
+for the Runtime and Reflection phases.
+
+> A quieter blocker to note: contributors to the Risk Map are serialised — *"I can only have so
+> many people in queue to modify the same space at any one time"* — and WS2's telemetry work is
+> ahead of ADLC in that queue. Worth knowing before anyone commits to a date.
+
+---
+
+### §5. Risk Map Review of the MCP Paper — Still Zero Volunteers (5') — Chairs / David LaBianca
+
+*[#178](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/178) — opened Aug 31, still unlabeled, still unassigned. Ten days.*
+
+[`secure-ai-tooling#507`](https://github.com/cosai-oasis/secure-ai-tooling/pull/507) adds **46 new entries and updates 30**, taking the framework from
+37 to 67 controls and 36 to 52 risks. **As of this morning, not one of the ten review areas has an
+assignee**, and eight of the ten have zero comments.
+
+**Review against V1, not V2.** David LaBianca was explicit on Sep 3: entries were decomposed in
+June 2026 from the **v1** whitepaper with citations line-pinned to that revision. Check faithfulness
+against V1 first; bring V2 divergences forward as new issues afterwards. Finding where V2 moved
+away from what an entry was derived from is the most valuable outcome — one case is already known,
+a delegation control whose source text inverted its recommendation between revisions. Framework
+mappings incompatible with currently supported versions were redacted from the PR, and a
+re-pinning exercise will update them later.
+
+**Claim an area by commenting on its issue.**
+
+| Area | Entries | Issue | Volunteer |
+|---|---|---|---|
+| Identity, authentication and consent | 12 | [#512](https://github.com/cosai-oasis/secure-ai-tooling/issues/512) | |
+| Secrets and credential management | 8 | [#513](https://github.com/cosai-oasis/secure-ai-tooling/issues/513) | |
+| Authorization and delegation-chain integrity | 10 | [#514](https://github.com/cosai-oasis/secure-ai-tooling/issues/514) | |
+| Tool supply chain | 8 | [#515](https://github.com/cosai-oasis/secure-ai-tooling/issues/515) | |
+| Isolation and containment | 5 | [#516](https://github.com/cosai-oasis/secure-ai-tooling/issues/516) | |
+| Network enforcement | 5 | [#517](https://github.com/cosai-oasis/secure-ai-tooling/issues/517) | |
+| Observability, audit and accountability | 7 | [#518](https://github.com/cosai-oasis/secure-ai-tooling/issues/518) | |
+| Prompt injection and context integrity | 4 | [#519](https://github.com/cosai-oasis/secure-ai-tooling/issues/519) | |
+| The classical AI/ML estate | 13 | [#520](https://github.com/cosai-oasis/secure-ai-tooling/issues/520) | |
+| Cross-cutting *(CoSAI-RM SIG session, WS4 participation)* | 4 | [#521](https://github.com/cosai-oasis/secure-ai-tooling/issues/521) | |
+
+**Three of these have obvious homes in the room today.** Areas 3, 5 and 7 map onto delegation,
+containment and observability work WS4 members are already deep in — §1, §3 and §4c respectively.
+If the containment authors take area 5 and the ADLC observability thread takes area 7, half the
+problem is the same reading twice.
+
+---
+
+### §6. WS2 Telemetry — Feedback Closes Monday (4') — Chairs
+
+Josiah Hagen walked WS4 through the [telemetry roadmap](https://github.com/cosai-oasis/ws2-defenders/blob/main/telemetry/CoSAI-AI-Telemetry-RFC.md) on Sep 3. It maps OCSF and OpenTelemetry
+telemetry requests to verified attack patterns, prioritising **threat detection first, incident
+response second, quality assurance and auditing third**. An Abu Dhabi bank has implemented the work
+in progress successfully. Open questions remain at the end of the document for the working group to
+close before publication, and the group decided to emphasise that **sampling is the major problem
+for security telemetry** — head sampling loses exactly the events that matter.
+
+| | |
+|---|---|
+| **Deadline** | **Monday 2026-09-14**, via GitHub issues or PRs. TSC co-chair review is now formally tracked — [cosai-tsc#67](https://github.com/cosai-oasis/cosai-tsc/issues/67), owner Jason Garman, target **2026-09-16**. WS4's window closes first |
+| **Moving in parallel** | David LaBianca committed at the Sep 8 TSC to review Josiah's three new risks and one new control **this week**, folding them into a stacked PR. Telemetry finalisation depends on the CoSAI-RM changes coming out of the MCP and agentic-identity decompositions — the same corpus as §5 |
+| **Form of feedback** | Actionable, rephrased editing suggestions — not high-level critique. Add your name **and a timeline** |
+| **If you are doing OCSF or OpenTelemetry work** | Consult **Appendices D and E** to check your planned work aligns |
+| **Reciprocity worth naming** | WS4's MCP decomposition shrank that paper's ask on the CoSAI-RM to three risks and one control. The two workstreams' outputs are already interlocking as intended |
+
+**Last week this produced no named WS4 reviewers.** It has four days left.
+
+| Reviewer | Section / lens | Committed by |
+|---|---|---|
+| | | |
+
+Also live and adjacent: David Pierce's stop-reason-as-stateful-enum proposal
+([Levaj2000/ocsf-schema#1](https://github.com/Levaj2000/ocsf-schema/pull/1)), which OCSF responded well to — adding HTTP-style state to the stop
+code as the instrumentation point for injection, poor character escaping and malformed tokens.
+Raymond Sheh is coordinating NIST AI RMF work with the WS2 telemetry SIG.
+
+---
+
+### §7. Close-Outs (4') — Chairs
+
+**[PR #116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) identity playbook — 90 days open, author reassigned.** Raised here rather than
+under stale PRs because §1 makes it live: it is the closest WS4 artifact to ODIS's Passport/Bridge/
+Router model and it has nobody attending it. Adopt it, or close it and fold the content into the
+ODIS mapping note?
+
+**The interop document.** Jeff Leva offered on Sep 3 to reshare the document mapping Agent
+Credentials, Trust Graph, OCSF and the layers each owns. It is the instrument WS4 has been missing
+— and the natural home for the ODIS mapping asked for in §1b. **Ask: reshare it, and say where it
+lives permanently.**
+
+**AI-generated content in the repos — and #156 is suddenly live again.** The Sep 8 TSC spent real
+time on [cosai-tsc#29](https://github.com/cosai-oasis/cosai-tsc/issues/29): issues filling with low-quality AI-generated comments, auto-replies
+arriving via API, and LLM phrasing landing in documents. OASIS is drafting policy. Josiah Hagen
+proposed requiring **iCLA verification** to establish accountability; automated AI-content
+detection was judged ineffective, leaving maintainers on manual sniff tests and user signals.
+**I took the action to assess #29 — close or consolidate — align it with the Monday cross-workstream
+sync, and evaluate a workstream best-practices document.** Three things in this repo bear on it,
+and WS4 is better placed than most to say what works:
+
+- **[#156](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/156)** below is the contributor-screening question the TSC is now asking org-wide.
+- **[PR #92](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/92)** would give us an AI usage policy; `CONTRIBUTING.md`'s policy heading is an empty stub, and the PR needs a rebase.
+- Bill Stout's Sep 3 question about digesting hundred-page documents is the *constructive* half of the same argument — Kevin Calloway and Josiah both endorsed AI-assisted summarisation with human oversight retained.
+
+**[#156](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/156) contributor screening — 40 days, unlabeled, unassigned.** The Aug 20 call decided
+against running the automation in CoSAI repos; Imran closed PR #157 and rewrote #156 as a reference
+runbook. Accept as a documented pattern, or decline? Either way, label it and close the thread.
+
+**[#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) summary — 3 meetings carried, still unowned.** Closed Aug 13 after 102 comments; the
+action to relocate the useful content is assigned to *the group*, which means nobody. Needs a name
+and a destination.
+
+**Two accepted RFCs never landed in `RFCs/`.** `CONTRIBUTING.md` says approved RFCs are committed
+there with the originating issue number. The directory holds only `RFC-6.md` and `RFC-50.md` —
+[#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) (Agent Credentials) and [#113](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/113) (Multimodal) are missing, so two of our largest
+drafts have no in-repo anchor. Small, mechanical, and it is the concrete half of the GitHub-first
+decision.
+
+**[Discussion #129](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/129)** — 21 comments, last activity Aug 28, never dispositioned.
+
+---
+
+### §8. Written Updates — No Time Allocated
+
+| Topic | Status |
+|---|---|
+| **Agent Credentials paper** | **Slipped to October** — Benedict Lau reported a slight delay on Sep 3; early draft skeleton for broader review. Working with Rithikha Rajamohan. The Sep 3 group call spent its time on whether an agent manifest is *evidence* or a *credential*, and took an action to meet with Imran Siddique to settle manifests and traces — expect [#149](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/149)'s fate to be decided inside the paper rather than as a standalone RFC. [Draft](https://docs.google.com/document/d/1ILDtbNJw_1GCj6V9uXaDgMLGKQJR9JJqUNWMef9Vamk/edit) *(workstream access)* |
+| **Multimodal threat taxonomy** ([#113](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/113)) | **Late October**, Shriti Priya. Resolving ambiguities; modality-agnostic taxonomy. Date is owner-stated but not yet team-confirmed |
+| **Trust Graph** | Meets alternate Thursdays 09:30–11:00 ET; co-chairs include Rithikha Rajamohan and Kapil Singh. Hypergraph representation of delegation and agent state. Overlaps Agent Credentials by acknowledgement — *"we constantly talk about whether we should be combining into one effort."* **It has no GitHub issue** — the only WS4 effort that is genuinely untracked, and the proof behind the "nobody holds the map" argument in §2 |
+| **MCP V2.x residuals** ([#163](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/163)) | Two items: one editorial, one needing a chair call on citing a pre-release OWASP document normatively. No movement since Aug 12 |
+| **AI usage policy and long-document review** | Now a §7 item — the Sep 8 TSC picked up the same argument org-wide |
+| **Stale PRs** | [#116](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/116) identity playbook (§7) · [#92](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/92) AI usage policy, needs a rebase · [#89](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/89) MCP conformance guide · [#72](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/72) practical guide patterns |
+| **Meeting links for public contributors** | Done — Slack channel, mailing list and onboarding pointer are now in this agenda's header. Matthew Gladney's Aug 27 ask |
+
+---
+
+### Action Item Follow-ups
+
+| Owner | Action | Status |
+|---|---|---|
+| Jeff Leva | Lead and steward the containment follow-on paper | ✅ **Done** — Editor as of Sep 5, assigned on [#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172), skeleton [PR #181](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/181) open with three dates |
+| John Cavanaugh | Add research findings on design and security gaps to [#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172) | ✅ **Done** — 3-page comparison PDF posted Sep 3 |
+| Kevin Calloway | Introduce a containment-interested contact to WS4 | ✅ **Done** — Jason Bowman introduced Sep 3; email to Claudia. **Still needs Slack access and an intro to Jeff** |
+| Bill Stout | Strip soft-decommissioning from RFC [#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) | ✅ **Done** — struck through in the RFC body. Organizational definitions still open (§4b) |
+| Sarah Novotny | Update the Agent Credentials timeline to October | ✅ **Done** — carried into the Sep 8 TSC report |
+| Sarah Novotny | Discuss containment-paper placement with David LaBianca | ✅ **Done** — resolved at the TSC: broad WS4 workstream, not the ADLC SIG |
+| Sarah Novotny | Add Slack and meeting links to the agenda for public contributors | ✅ **Done** — agenda header |
+| Emrick Donadei | Resolve the observability component question | ✅ **Done, differently than expected** — found `AuditRecordRepository` already covers it; proposes withdrawing the RFC (§4c) |
+| Sarah Novotny / Ian Molloy | Recruit ADLC SIG co-chairs ([cosai-tsc#63](https://github.com/cosai-oasis/cosai-tsc/issues/63)) | ✅ **Done** — Courtenay Ngo and Matthew Gladney nominated at the Sep 8 TSC; consensus closes Fri Sep 11 (§4a) |
+| Claudia Rauch (OASIS) | Post the ADLC co-lead call for consensus to the TSC list | ✅ **Done** — Sep 9 |
+| **Unassigned** → **Courtenay Ngo** | **Lead the ADLC definitional / landscape paper** | ✅ **Done — taken as lead editor** (§4a). Was the largest unowned dependency in WS4 |
+| Courtenay Ngo | Settle *definition* vs *landscape*, then set a target date | ❓ **New** — everything downstream sequences behind it (§4a) |
+| Sarah Novotny | Lead the next ADLC session to transition the incoming co-leads | ❓ **New (Sep 8 TSC)** — §4a |
+| Sarah Novotny | Assess [cosai-tsc#29](https://github.com/cosai-oasis/cosai-tsc/issues/29), align with the Monday cross-workstream sync, evaluate a workstream best-practices document | ❓ **New (Sep 8 TSC)** — §7 |
+| Sarah Novotny | Audit [#163](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/163) for whether V2.x needs a follow-on version | ❓ Not started |
+| Chairs | Get [cosai-tsc#66](https://github.com/cosai-oasis/cosai-tsc/pull/66) reviewed and merged — WS4 roadmap rows | ⚠️ **Open, zero reviews, third week.** Roadmap still shows one WS4 row (§2) |
+| David LaBianca | Fold Josiah's three risks and one control into a stacked PR this week | ❓ **New (Sep 8 TSC)** — §6 |
+| John Cavanaugh | Post the research findings to Slack | ❓ No evidence — posted to [#172](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/172) instead, which is arguably better under the GitHub-first decision |
+| Jeff Leva | Reshare the interop document (layer ownership: Trust Graph, Agent Credentials, OCSF) | ❓ New (Sep 3) — §7, and §1b needs it |
+| Raymond Sheh | Coordinate RMF work with Josiah Hagen offline | ❓ New (Sep 3) |
+| Raymond Sheh | Attend the WS2 telemetry SIG meeting | ❓ New (Sep 3) |
+| Raymond Sheh | Review RFC [#170](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/170) against his notes | ✅ **Done** — substantive review posted Sep 1 on downstream dependencies |
+| The group | Review risks and controls **against MCP V1** before proposing V2 additions | 🔄 **On this agenda** (§5) |
+| The group | Review [#178](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/178) and claim an area | ⚠️ **Zero claimed in 10 days** — §5 |
+| The group | Review the telemetry document — actionable edits, name + timeline, by Sep 14 | ⚠️ **4 days left, no WS4 reviewers named** — §6 |
+| Chairs / CoSAI-RM SIG | Confirm the [#175](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/175) withdrawal and control reframe | ❓ **New — one comment, unblocks ADLC risk drafting** (§4c) |
+| Chairs | Merge [PR #181](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/181) and request the three named TSC reviewers | ❓ **New** — approved and mergeable, no reviewers requested (§3) |
+| **Unassigned** | **Own an ODIS ↔ WS4 mapping note** | ❓ **New — main ask of §1b** |
+| Nir Paz | ODIS event remote link | ✅ **Closed by §1** — event held Aug 28; superseded by the readout |
+| Nir Paz | ODIS README PR | ⚠️ Carried Over — 4 meetings; §1 |
+| Imran Siddique | Update the RFC re: Agent Card integration | ⚠️ Carried Over — 3 meetings (since Aug 20) |
+| Imran Siddique | Draft the standards-integration diagram | ⚠️ Carried Over — 3 meetings (since Aug 20) |
+| Imran Siddique | Post the Phase 1 disposition summary | ⚠️ Carried Over — **5 meetings, 32 days** (since Aug 9). *File where the RFC directs — it may not be this repo* |
+| Imran Siddique, Raghuram Yeluri | Reconcile the verifier / trace-generation architecture | ⚠️ Carried Over — 2 meetings |
+| Agent Credential group | Unify Manifest and Credential schemas | 🔄 In progress — the Sep 3 group call took it up as evidence-vs-credential; action to meet with Imran |
+| Daniel Major | Review the Agent Manifest proposal | ⚠️ Carried Over — 4 meetings (since Aug 13) |
+| The group | Summarize [#99](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/issues/99) into a permanent document | ⚠️ Carried Over — 3 meetings; **unowned** (§7) |
+| The group | Volunteer to lead two ADLC meetings a month | ⚠️ Carried Over — 4 meetings; still unfilled (§4a) |
+| Claudia Rauch (OASIS) | Coordinate blog promotion with Mary Beth | ❓ Unknown |
+
+**Status Key:** ✅ Done · 🔄 In Progress · ⚠️ Carried Over · ❓ Unknown
+
+Done items stay on this agenda for visibility and drop off next week.
+
+---
+
+### Reference Materials
+
+- [Discussion #180](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/180) — WS4 agenda, Sep 3 · [Discussion #127](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/discussions/127) — WS4 agenda for Jun 25, the call ODIS was presented on
+- `agenda_drafts/ws4/2026-09-08-tsc-report.md` ([PR #183](https://github.com/cosai-oasis/ws4-secure-design-agentic-systems/pull/183)) — the deliverables view taken to the Sep 8 TSC
+- TSC minutes [Sep 1](https://github.com/cosai-oasis/cosai-tsc/blob/main/tsc-meeting-minutes/2026-09-01.md) · [Sep 8](https://github.com/cosai-oasis/cosai-tsc/blob/main/tsc-meeting-minutes/2026-09-08.md) *(draft)* · [deliverables roadmap](https://github.com/cosai-oasis/cosai-tsc/blob/main/TSC%20Deliverables/roadmap.md)
+- TSC issues: [#29](https://github.com/cosai-oasis/cosai-tsc/issues/29) repo access / AI content · [#49](https://github.com/cosai-oasis/cosai-tsc/issues/49) standup · [#52](https://github.com/cosai-oasis/cosai-tsc/issues/52) scope reassessment · [#62](https://github.com/cosai-oasis/cosai-tsc/issues/62) ODIS follow-up · [#63](https://github.com/cosai-oasis/cosai-tsc/issues/63) ADLC recruitment · [#67](https://github.com/cosai-oasis/cosai-tsc/issues/67) telemetry co-chair review · [PR #66](https://github.com/cosai-oasis/cosai-tsc/pull/66) WS4 roadmap rows
+- [`secure-ai-tooling#507`](https://github.com/cosai-oasis/secure-ai-tooling/pull/507) MCP decomposition · [`#501`](https://github.com/cosai-oasis/secure-ai-tooling/pull/501) observability · [`#473`](https://github.com/cosai-oasis/secure-ai-tooling/pull/473) components
+- Adjacent standards WS4 tracks alongside ODIS: IETF **WIMSE**, the OAuth token-exchange family, and NIST **NCCoE** work on AI agent identity and authorization


### PR DESCRIPTION
Twenty minutes are committed to ODIS, per the announcement on the 2026-09-03 call: a readout of the 2026-08-28 kickoff hosted at NVIDIA, plus the work going forward. Section 1 splits that into a 10' readout and a 10' discussion, and carries the six threads left unanswered after the June 25 presentation plus two raised on 2026-09-03.

Built from the 2026-09-03 WS4 minutes, chat log and attendance; the 2026-09-01 and 2026-09-08 TSC minutes; and repo issue and PR state.

Notable changes since the 2026-09-03 agenda:

- Containment follow-on has an Editor and three dates; the item moves from recruiting to work in progress.
- ADLC SIG leadership resolved. Two co-lead volunteers went to a call for consensus that closes 2026-09-11, and the definitional paper has a lead editor -- the workstream's largest unowned dependency.
- Observability RFC #175 is being withdrawn rather than delivered; the behavioural half is refiled as a control.
- The 2026-09-08 TSC lacked quorum, so the scope and roadmap reassessment did not happen and is deferred.
- Risk map review #178 still has zero volunteers across ten areas.

The ODIS reference document is not public. Its link is deliberately omitted and a note in section 1 says why, so the draft can be promoted to a Discussion without widening that document's audience.

Form: AI-assisted drafting from meeting minutes, issues and pull requests, under my direction. Section content and the time allocation are mine.